### PR TITLE
Fix model ctor exception behaviour.

### DIFF
--- a/src/model.cpp
+++ b/src/model.cpp
@@ -61,6 +61,7 @@ model::model(const recipe& rec, const domain_decomposition& decomp):
             });
     }
 
+    tasks.wait();
     cell_groups_.reserve(n_group);
     for (auto& f: cell_group_future) {
         cell_groups_.push_back(f.get());

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -1,5 +1,7 @@
 #include <model.hpp>
 
+#include <future>
+#include <type_traits>
 #include <vector>
 
 #include <backends.hpp>
@@ -14,34 +16,55 @@
 namespace nest {
 namespace mc {
 
+template <typename F, typename R=typename std::result_of<F()>::type>
+std::future<R> run_packaged(threading::task_group& g, const F& f) {
+    auto task=std::make_shared<std::packaged_task<R ()>>(f);
+    auto r=task->get_future();
+
+    g.run([task] { (*task)(); });
+    return std::move(r);
+}
+
 model::model(const recipe& rec, const domain_decomposition& decomp):
     domain_(decomp)
 {
+    using util::make_span;
+
     // set up communicator based on partition
     communicator_ = communicator_type(domain_.gid_group_partition());
 
     // generate the cell groups in parallel, with one task per cell group
-    cell_groups_.resize(domain_.num_local_groups());
+    auto n_group = domain_.num_local_groups();
+    std::vector<std::future<cell_group_ptr>> cell_group_future(n_group);
 
     // thread safe vector for constructing the list of probes in parallel
     threading::parallel_vector<probe_record> probe_tmp;
 
-    threading::parallel_for::apply(0, cell_groups_.size(),
-        [&](cell_gid_type i) {
-            PE("setup", "cells");
+    threading::task_group tasks;
+    for (auto i: make_span(0, n_group)) {
+        cell_group_future[i] = run_packaged(tasks,
+            [&, i]() -> cell_group_ptr {
+                PE("setup", "cells");
 
-            auto group = domain_.get_group(i);
-            std::vector<util::unique_any> cell_descriptions(group.end-group.begin);
+                auto group = domain_.get_group(i);
+                std::vector<util::unique_any> cell_descriptions(group.end-group.begin);
 
-            for (auto gid: util::make_span(group.begin, group.end)) {
-                auto i = gid-group.begin;
-                cell_descriptions[i] = rec.get_cell_description(gid);
-            }
+                for (auto gid: make_span(group.begin, group.end)) {
+                    auto i = gid-group.begin;
+                    cell_descriptions[i] = rec.get_cell_description(gid);
+                }
 
-            cell_groups_[i] = cell_group_factory(
-                    group.kind, group.begin, cell_descriptions, domain_.backend());
-            PL(2);
-        });
+                auto r = cell_group_factory(group.kind, group.begin, cell_descriptions, domain_.backend());
+                PL(2);
+
+                return std::move(r);
+            });
+    }
+
+    cell_groups_.reserve(n_group);
+    for (auto& f: cell_group_future) {
+        cell_groups_.push_back(f.get());
+    }
 
     // store probes
     for (const auto& c: cell_groups_) {

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -51,6 +51,7 @@ set(TEST_SOURCES
     test_math.cpp
     test_matrix.cpp
     test_mechanisms.cpp
+    test_model_ctor_exception.cpp
     test_multi_event_stream.cpp
     test_nop.cpp
     test_optional.cpp

--- a/tests/unit/test_model_ctor_exception.cpp
+++ b/tests/unit/test_model_ctor_exception.cpp
@@ -1,0 +1,47 @@
+#include "../gtest.h"
+
+#include <recipe.hpp>
+#include <rss_cell.hpp>
+#include <model.hpp>
+
+using namespace nest::mc;
+
+struct boom {};
+
+struct throwing_recipe: public recipe {
+    throwing_recipe(unsigned n_cell, unsigned throwing_gid):
+        n_(n_cell), boom_(throwing_gid) {}
+
+    cell_size_type num_cells() const override { return n_; }
+
+    util::unique_any get_cell_description(cell_gid_type gid) const override {
+        return gid==boom_? throw boom{}: rss_cell::rss_cell_description(0, 1, 1000);
+    }
+
+    cell_kind get_cell_kind(cell_gid_type) const override {
+        return cell_kind::regular_spike_source;
+    }
+
+    cell_count_info get_cell_count_info(cell_gid_type) const override {
+        return {0, 0, 0};
+    }
+
+    std::vector<cell_connection> connections_on(cell_gid_type) const override {
+        return std::vector<cell_connection>();
+    }
+
+    cell_size_type n_, boom_;
+};
+
+void run_model_ctor(const recipe& rec) {
+    domain_decomposition dd(rec, group_rules{1u, backend_policy::use_multicore});
+    model m(rec, dd);
+}
+
+TEST(model_exception, good_recipe) {
+    EXPECT_NO_THROW(run_model_ctor(throwing_recipe(10000,-1)));
+}
+
+TEST(model_exception, bad_recipe) {
+    EXPECT_THROW(run_model_ctor(throwing_recipe(10000,5555)), boom);
+}


### PR DESCRIPTION
Fixes #310.

* Use `std::packaged_task` to wrap recipe description queries in `model` constructor.
* Add unit test that is sensitive to correct exception handling in cell group creation tasks in the `model` constructor.