### PR TITLE
Rename NestMC references, names etc. to Arbor.

### DIFF
--- a/.ycm_extra_conf.py
+++ b/.ycm_extra_conf.py
@@ -36,7 +36,7 @@ import ycm_core
 # CHANGE THIS LIST OF FLAGS. YES, THIS IS THE DROID YOU HAVE BEEN LOOKING FOR.
 flags = [
     '-DNDEBUG',
-    '-DNMC_HAVE_CTHREAD',
+    '-DARB_HAVE_CTHREAD',
     '-std=c++11',
     '-x',
     'c++',
@@ -54,7 +54,7 @@ flags = [
     'modcc',
     '-I',
     '/cm/shared/apps/cuda/8.0.44/include',
-    '-DNMC_HAVE_GPU'
+    '-DARB_HAVE_GPU'
 ]
 
 # Set this to the absolute path to the folder (NOT the file!) containing the

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,23 +29,23 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 #----------------------------------------------------------
 # Option to enable assertions
 #----------------------------------------------------------
-option(NMC_WITH_ASSERTIONS "enable EXPECTS() assertions in code" OFF)
-if(NMC_WITH_ASSERTIONS)
-    add_definitions("-DNMC_HAVE_ASSERTIONS")
+option(ARB_WITH_ASSERTIONS "enable EXPECTS() assertions in code" OFF)
+if(ARB_WITH_ASSERTIONS)
+    add_definitions("-DARB_HAVE_ASSERTIONS")
 endif()
 
 #----------------------------------------------------------
 # Option to enable traces
 #----------------------------------------------------------
-option(NMC_WITH_TRACE "enable TRACE() macros in code" OFF)
-if(NMC_WITH_TRACE)
-    add_definitions("-DNMC_HAVE_TRACE")
+option(ARB_WITH_TRACE "enable TRACE() macros in code" OFF)
+if(ARB_WITH_TRACE)
+    add_definitions("-DARB_HAVE_TRACE")
 endif()
 
 #----------------------------------------------------------
 # Option to disable auto running of modcc compiler
 #----------------------------------------------------------
-option(NMC_AUTO_RUN_MODCC_ON_CHANGES
+option(ARB_AUTO_RUN_MODCC_ON_CHANGES
   "Rerun modcc compiler whenever *.mod file or modcc compiler change" ON)
 
 #----------------------------------------------------------
@@ -55,17 +55,17 @@ set(EXTERNAL_LIBRARIES "")
 set(EXTERNAL_INCLUDES "")
 
 #----------------------------------------------------------
-# list of libraries built inside NestMC
+# list of libraries built inside Arbor
 #----------------------------------------------------------
-set(NESTMC_LIBRARIES "")
+set(ARB_LIBRARIES "")
 
 #----------------------------------------------------------
 # Threading model selection
 #----------------------------------------------------------
-set(NMC_THREADING_MODEL "cthread" CACHE STRING "set the threading model, one of cthread/tbb/serial")
-set_property(CACHE NMC_THREADING_MODEL PROPERTY STRINGS cthread tbb serial )
+set(ARB_THREADING_MODEL "cthread" CACHE STRING "set the threading model, one of cthread/tbb/serial")
+set_property(CACHE ARB_THREADING_MODEL PROPERTY STRINGS cthread tbb serial )
 
-if(NMC_THREADING_MODEL MATCHES "tbb")
+if(ARB_THREADING_MODEL MATCHES "tbb")
     # download and build TBB
     include(${CMAKE_SOURCE_DIR}/cmake/tbb/TBBGet.cmake)
     include(${CMAKE_SOURCE_DIR}/cmake/tbb/TBBBuild.cmake)
@@ -75,8 +75,8 @@ if(NMC_THREADING_MODEL MATCHES "tbb")
     # configure TBB
     find_package(TBB REQUIRED tbb tbbmalloc)
 
-    add_definitions(-DNMC_HAVE_TBB)
-    set(NMC_WITH_TBB TRUE)
+    add_definitions(-DARB_HAVE_TBB)
+    set(ARB_WITH_TBB TRUE)
 
     # The TBB CMake package creates the TBB::tbb and TBB:tbbmalloc targets.
     # The following should be sufficient, however on some systems (e.g. Cray PE),
@@ -91,11 +91,11 @@ if(NMC_THREADING_MODEL MATCHES "tbb")
     # The TBB headers are in the downloaded TBB source
     list(APPEND EXTERNAL_INCLUDES ${tbb_root}/include)
 
-elseif(NMC_THREADING_MODEL MATCHES "cthread")
+elseif(ARB_THREADING_MODEL MATCHES "cthread")
 
     find_package(Threads REQUIRED)
-    add_definitions(-DNMC_HAVE_CTHREAD)
-    set(NMC_WITH_CTHREAD TRUE)
+    add_definitions(-DARB_HAVE_CTHREAD)
+    set(ARB_WITH_CTHREAD TRUE)
     list(APPEND EXTERNAL_LIBRARIES ${CMAKE_THREAD_LIBS_INIT})
 
     if(CMAKE_USE_PTHREADS_INIT)
@@ -116,8 +116,8 @@ endif()
 #----------------------------------------------------------
 # CUDA support
 #----------------------------------------------------------
-option(NMC_WITH_CUDA "use CUDA for GPU offload" OFF)
-if(NMC_WITH_CUDA)
+option(ARB_WITH_CUDA "use CUDA for GPU offload" OFF)
+if(ARB_WITH_CUDA)
     find_package(CUDA REQUIRED)
 
     # Turn off annoying and incorrect warnings generated in the JSON file.
@@ -125,14 +125,14 @@ if(NMC_WITH_CUDA)
     set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS};-Xcudafe \"--diag_suppress=not_used_in_template_function_params\";-Xcudafe \"--diag_suppress=cast_to_qualified_type\")
 
     # set the CUDA target specfic flags
-    # code regions protected by NMC_HAVE_CUDA should only be available to the CUDA
-    # compiler, which regions protected by NMC_HAVE_GPU are visible to both host
+    # code regions protected by ARB_HAVE_CUDA should only be available to the CUDA
+    # compiler, which regions protected by ARB_HAVE_GPU are visible to both host
     # and device compiler when targetting GPU.
-    set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS};-DNMC_HAVE_CUDA)
-    set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS};-DNMC_HAVE_GPU)
+    set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS};-DARB_HAVE_CUDA)
+    set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS};-DARB_HAVE_GPU)
     set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS};-arch=sm_60)
 
-    add_definitions(-DNMC_HAVE_GPU)
+    add_definitions(-DARB_HAVE_GPU)
     include_directories(SYSTEM ${CUDA_INCLUDE_DIRS})
     list(APPEND EXTERNAL_LIBRARIES ${CUDA_LIBRARIES})
 endif()
@@ -140,28 +140,28 @@ endif()
 #----------------------------------------------------------
 # Cray/BGQ/Generic Linux/other flag?
 #----------------------------------------------------------
-set(NMC_SYSTEM_TYPE "Generic" CACHE STRING 
+set(ARB_SYSTEM_TYPE "Generic" CACHE STRING 
     "Choose a system type to customize flags")
-set_property(CACHE NMC_SYSTEM_TYPE PROPERTY STRINGS Generic Cray BGQ )
+set_property(CACHE ARB_SYSTEM_TYPE PROPERTY STRINGS Generic Cray BGQ )
 
 # Cray specific flags
-if(${NMC_SYSTEM_TYPE} MATCHES "Cray")
+if(${ARB_SYSTEM_TYPE} MATCHES "Cray")
     # we no longer set the -dynamic flag for the compilere here, instead dynamic
     # linking should be enabled by the user by setting the environment variable:
     #   CRAYPE_LINK_TYPE=dynamic
     #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -dynamic")
-    add_definitions(-DNMC_HAVE_CRAY)
+    add_definitions(-DARB_HAVE_CRAY)
 endif()
 
 #----------------------------------------------------------
 # MPI support
 #----------------------------------------------------------
-set(NMC_DISTRIBUTED_MODEL "serial" CACHE STRING "set the global communication model, one of serial/mpi/dryrun")
-set_property(CACHE NMC_DISTRIBUTED_MODEL PROPERTY STRINGS serial mpi dryrun)
+set(ARB_DISTRIBUTED_MODEL "serial" CACHE STRING "set the global communication model, one of serial/mpi/dryrun")
+set_property(CACHE ARB_DISTRIBUTED_MODEL PROPERTY STRINGS serial mpi dryrun)
 
-if(NMC_DISTRIBUTED_MODEL MATCHES "mpi")
+if(ARB_DISTRIBUTED_MODEL MATCHES "mpi")
    # BGQ specific flags
-   if(${NMC_SYSTEM_TYPE} MATCHES "BGQ" )
+   if(${ARB_SYSTEM_TYPE} MATCHES "BGQ" )
       # On BGQ, set CXX to the mpi wrapper, and pass it a static
       add_definitions(-DMPICH2_CONST=const)
       set(MPI_FOUND TRUE)
@@ -171,46 +171,46 @@ if(NMC_DISTRIBUTED_MODEL MATCHES "mpi")
       find_package(MPI REQUIRED)
     endif()
     include_directories(SYSTEM ${MPI_C_INCLUDE_PATH})
-    add_definitions(-DNMC_HAVE_MPI)
+    add_definitions(-DARB_HAVE_MPI)
 
     # unfortunate workaround for C++ detection in system mpi.h
     add_definitions(-DMPICH_SKIP_MPICXX=1 -DOMPI_SKIP_MPICXX=1)
     set_property(DIRECTORY APPEND_STRING PROPERTY COMPILE_OPTIONS "${MPI_C_COMPILE_FLAGS}")
 
-    set(NMC_WITH_MPI TRUE)
+    set(ARB_WITH_MPI TRUE)
 
-elseif(NMC_DISTRIBUTED_MODEL MATCHES "dryrun")
-    add_definitions(-DNMC_HAVE_DRYRUN)
-    set(NMC_WITH_DRYRUN TRUE)
+elseif(ARB_DISTRIBUTED_MODEL MATCHES "dryrun")
+    add_definitions(-DARB_HAVE_DRYRUN)
+    set(ARB_WITH_DRYRUN TRUE)
 
-elseif(NMC_DISTRIBUTED_MODEL MATCHES "serial")
+elseif(ARB_DISTRIBUTED_MODEL MATCHES "serial")
     # no additional set up needed
 
 else()
-    message( FATAL_ERROR "-- Distributed communication model '${NMC_DISTRIBUTED_MODEL}' not supported, use one of serial/mpi/dryrun")
+    message( FATAL_ERROR "-- Distributed communication model '${ARB_DISTRIBUTED_MODEL}' not supported, use one of serial/mpi/dryrun")
 endif()
 
 #----------------------------------------------------------
 # Built-in profiler
 #----------------------------------------------------------
-option(NMC_WITH_PROFILING "use built-in profiling of miniapp" OFF)
-if(NMC_WITH_PROFILING)
-    add_definitions(-DNMC_HAVE_PROFILING)
+option(ARB_WITH_PROFILING "use built-in profiling of miniapp" OFF)
+if(ARB_WITH_PROFILING)
+    add_definitions(-DARB_HAVE_PROFILING)
 endif()
 
 #----------------------------------------------------------
 # vectorization target
 #----------------------------------------------------------
-set(NMC_VECTORIZE_TARGET "none" CACHE STRING "CPU target for vectorization {KNL,AVX,AVX2,AVX512}")
-set_property(CACHE NMC_VECTORIZE_TARGET PROPERTY STRINGS none KNL AVX AVX2 AVX512)
+set(ARB_VECTORIZE_TARGET "none" CACHE STRING "CPU target for vectorization {KNL,AVX,AVX2,AVX512}")
+set_property(CACHE ARB_VECTORIZE_TARGET PROPERTY STRINGS none KNL AVX AVX2 AVX512)
 
-if(NMC_VECTORIZE_TARGET STREQUAL "KNL")
+if(ARB_VECTORIZE_TARGET STREQUAL "KNL")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXXOPT_KNL}")
-elseif(NMC_VECTORIZE_TARGET STREQUAL "AVX")
+elseif(ARB_VECTORIZE_TARGET STREQUAL "AVX")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXXOPT_AVX}")
-elseif(NMC_VECTORIZE_TARGET STREQUAL "AVX2")
+elseif(ARB_VECTORIZE_TARGET STREQUAL "AVX2")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXXOPT_AVX2}")
-elseif(NMC_VECTORIZE_TARGET STREQUAL "AVX512")
+elseif(ARB_VECTORIZE_TARGET STREQUAL "AVX512")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXXOPT_AVX512}")
 endif()
 
@@ -232,22 +232,22 @@ endif()
 # Validation data generation
 #----------------------------------------------------------
 # destination directory for generated data
-set(NMC_VALIDATION_DATA_DIR "${PROJECT_SOURCE_DIR}/validation/data" CACHE PATH
+set(ARB_VALIDATION_DATA_DIR "${PROJECT_SOURCE_DIR}/validation/data" CACHE PATH
   "location of generated validation data")
 
 #----------------------------------------------------------
 # Whether to build validation data
 #----------------------------------------------------------
 # turn off by default
-option(NMC_BUILD_VALIDATION_DATA "generate validation data" OFF)
-if (NMC_BUILD_VALIDATION_DATA)
+option(ARB_BUILD_VALIDATION_DATA "generate validation data" OFF)
+if (ARB_BUILD_VALIDATION_DATA)
     # Whether to attempt to use julia to build validation data
     find_program(JULIA_BIN julia)
     if(JULIA_BIN STREQUAL "JULIA_BIN-NOTFOUND")
         message(STATUS "julia not found; will not automatically build validation data sets from julia scripts")
-        set(NMC_BUILD_JULIA_VALIDATION_DATA FALSE)
+        set(ARB_BUILD_JULIA_VALIDATION_DATA FALSE)
     else()
-        set(NMC_BUILD_JULIA_VALIDATION_DATA TRUE)
+        set(ARB_BUILD_JULIA_VALIDATION_DATA TRUE)
     endif()
 
     # Whether to attempt to use nrniv to build validation data
@@ -255,9 +255,9 @@ if (NMC_BUILD_VALIDATION_DATA)
     find_program(NRNIV_BIN nrniv)
     if(NRNIV_BIN STREQUAL "NRNIV_BIN-NOTFOUND")
         message(STATUS "nrniv not found; will not automatically build NEURON validation data sets")
-        set(NMC_BUILD_NRN_VALIDATION_DATA FALSE)
+        set(ARB_BUILD_NRN_VALIDATION_DATA FALSE)
     else()
-        set(NMC_BUILD_NRN_VALIDATION_DATA TRUE)
+        set(ARB_BUILD_NRN_VALIDATION_DATA TRUE)
     endif()
 endif()
 
@@ -279,7 +279,7 @@ endif()
 # Setup subdirs
 #----------------------------------------------------------
 # only include validation data if flag is set
-if(NMC_BUILD_VALIDATION_DATA)
+if(ARB_BUILD_VALIDATION_DATA)
     add_subdirectory(validation)
 endif()
 

--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ cd tests
 
 ## MPI
 
-Set the `NMC_WITH_MPI` option either via the ccmake interface, or via the command line as shown below.
+Set the `ARB_WITH_MPI` option either via the ccmake interface, or via the command line as shown below.
 To ensure that CMake detects MPI correctly, you should specify the MPI wrapper for the compiler by setting the `CXX` and `CC` environment variables.
 
 ```
 export CXX=mpicxx
 export CC=mpicc
-cmake <path to CMakeLists.txt> -DNMC_WITH_MPI=ON
+cmake <path to CMakeLists.txt> -DARB_WITH_MPI=ON
 ```
 
 ## TBB
@@ -57,7 +57,7 @@ When TBB is installed, it comes with some scripts that can be run to set up the 
 The scripts set the `TBB_ROOT` environment variable, which is used by the CMake configuration to find TBB.
 
 ```
-cmake <path to CMakeLists.txt> -DNMC_THREADING_MODEL=tbb
+cmake <path to CMakeLists.txt> -DARB_THREADING_MODEL=tbb
 ```
 
 ### TBB on Cray systems
@@ -71,11 +71,11 @@ Note, the CMake package provided by TBB is very fragile, and won't work if CMake
 
 ```
 export CRAYPE_LINK_TYPE=dynamic
-cmake <path-to-arbor-source> -DNMC_THREADING_MODEL=tbb
+cmake <path-to-arbor-source> -DARB_THREADING_MODEL=tbb
 
 # NOTE: specifying CMAKE_SYSTEM_NAME won't work, instead let CMake automatically
 # detect the build environment as above.
-cmake <path-to-arbor-source> -DNMC_THREADING_MODEL=tbb  -DCMAKE_SYSTEM_NAME=CrayLinuxEnvironment
+cmake <path-to-arbor-source> -DARB_THREADING_MODEL=tbb  -DCMAKE_SYSTEM_NAME=CrayLinuxEnvironment
 ```
 
 ```
@@ -137,15 +137,15 @@ cd build_knl
 # run cmake with all the magic flags
 export CC=`which icc`
 export CXX=`which icpc`
-cmake <path to CMakeLists.txt> -DCMAKE_BUILD_TYPE=release -DNMC_THREADING_MODEL=tbb -DNMC_WITH_PROFILING=ON -DNMC_VECTORIZE_TARGET=KNL
+cmake <path to CMakeLists.txt> -DCMAKE_BUILD_TYPE=release -DARB_THREADING_MODEL=tbb -DARB_WITH_PROFILING=ON -DARB_VECTORIZE_TARGET=KNL
 make -j
 ```
 
 The flags passed into cmake are described:
   - `-DCMAKE_BUILD_TYPE=release` : build in release mode with `-O3`.
-  - `-DNMC_THREADING_MODEL=tbb` : use TBB for threading on multi-core
-  - `-DNMC_WITH_PROFILING=ON` : use internal profilers that print profiling report at end
-  - `-DNMC_VECTORIZE_TARGET=KNL` : generate AVX512 instructions, alternatively you can use:
+  - `-DARB_THREADING_MODEL=tbb` : use TBB for threading on multi-core
+  - `-DARB_WITH_PROFILING=ON` : use internal profilers that print profiling report at end
+  - `-DARB_VECTORIZE_TARGET=KNL` : generate AVX512 instructions, alternatively you can use:
     - `AVX2` for Haswell & Broadwell
     - `AVX` for Sandy Bridge and Ivy Bridge
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -31,9 +31,9 @@ The easiest way to acquire the latest version of Arbor is to check the code out 
 
 .. code-block:: bash
 
-    git clone https://github.com/eth-cscs/nestmc-proto.git
+    git clone https://github.com/eth-cscs/arbor.git
 
-You can also point your browser to our `Github page <https://github.com/eth-cscs/nestmc-proto>`_ and download a zip file.
+You can also point your browser to our `Github page <https://github.com/eth-cscs/arbor>`_ and download a zip file.
 
 .. _install_desktop:
 

--- a/doc/math/model/symbols.tex
+++ b/doc/math/model/symbols.tex
@@ -35,7 +35,7 @@ We try to use the same units as NEURON, except for the specific membrane capacit
     $I_e$                     &   $nA$                  &  $10^{-9} \cdot A$                        & yes    \\
     \hline
 \end{tabular}
-\caption{The units chosen for parameters and variables in NEST MC. The NEURON column indicates whether the same units have been used as NEURON.}
+\caption{The units chosen for parameters and variables in Arbor. The NEURON column indicates whether the same units have been used as NEURON.}
 \label{tbl:units}
 \end{table}
 
@@ -146,7 +146,7 @@ which can be expressed more compactly as
 \end{equation}
 where $G\in\mathbb{R}^{n\times n}$ is the conductance matrix, and $v, i \in \mathbb{R}^{n}$ are voltage and current vectors respectively.
 
-In NestMC the weights are chosen such that the conductance has units $\mu S$, voltage has units $mV$ and current has units $nA$.
+In Arbor the weights are chosen such that the conductance has units $\mu S$, voltage has units $mV$ and current has units $nA$.
 
     \begin{center}
 

--- a/lmorpho/CMakeLists.txt
+++ b/lmorpho/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(lmorpho lmorpho.cpp lsystem.cpp lsys_models.cpp morphio.cpp)
 
-target_link_libraries(lmorpho LINK_PUBLIC nestmc)
+target_link_libraries(lmorpho LINK_PUBLIC arbor)
 target_link_libraries(lmorpho LINK_PUBLIC ${EXTERNAL_LIBRARIES})
 

--- a/lmorpho/morphio.cpp
+++ b/lmorpho/morphio.cpp
@@ -62,7 +62,7 @@ void multi_file::open(unsigned n) {
 
 using arb::io::swc_record;
 
-// TODO: Move this functionality to nestmc library.
+// TODO: Move this functionality to arbor library.
 std::vector<swc_record> as_swc(const arb::morphology& morph) {
     using kind = swc_record::kind;
     std::map<int, int> parent_end_id;

--- a/mechanisms/CMakeLists.txt
+++ b/mechanisms/CMakeLists.txt
@@ -10,14 +10,14 @@ set(mod_srcdir "${CMAKE_CURRENT_SOURCE_DIR}/mod")
 set(modcc_opt)
 set(mech_dir "${CMAKE_CURRENT_SOURCE_DIR}/multicore")
 file(MAKE_DIRECTORY "${mech_dir}")
-if(NMC_VECTORIZE_TARGET STREQUAL "KNL")
+if(ARB_VECTORIZE_TARGET STREQUAL "KNL")
     set(modcc_target "avx512")
-elseif(NMC_VECTORIZE_TARGET STREQUAL "AVX")
+elseif(ARB_VECTORIZE_TARGET STREQUAL "AVX")
     set(modcc_opt "-O")
     set(modcc_target "cpu")
-elseif(NMC_VECTORIZE_TARGET STREQUAL "AVX2")
+elseif(ARB_VECTORIZE_TARGET STREQUAL "AVX2")
     set(modcc_target "avx2")
-elseif(NMC_VECTORIZE_TARGET STREQUAL "AVX512")
+elseif(ARB_VECTORIZE_TARGET STREQUAL "AVX512")
     set(modcc_target "avx512")
 else()
     set(modcc_target "cpu")
@@ -46,20 +46,20 @@ build_modules(
 
 # Make a library with the implementations of the mechanism kernels
 
-if(NMC_WITH_CUDA)
+if(ARB_WITH_CUDA)
     # make list of the .cu files that implement the mechanism kernels
     foreach(mech ${mechanisms})
         list(APPEND cuda_mech_sources ${mech_dir}/${mech}_impl.cu)
     endforeach()
 
     # compile the .cu files into a library
-    cuda_add_library(gpu_mechanisms ${cuda_mech_sources})
+    cuda_add_library(arbormechcu ${cuda_mech_sources})
 
     # force recompilation on changes to modcc or the underlying .mod files
-    if (NMC_AUTO_RUN_MODCC_ON_CHANGES)
-        add_dependencies(gpu_mechanisms build_all_gpu_mods)
+    if (ARB_AUTO_RUN_MODCC_ON_CHANGES)
+        add_dependencies(arbormechcu build_all_gpu_mods)
     endif()
 
-    list(APPEND NESTMC_LIBRARIES gpu_mechanisms)
-    set(NESTMC_LIBRARIES "${NESTMC_LIBRARIES}" PARENT_SCOPE)
+    list(APPEND ARB_LIBRARIES arbormechcu)
+    set(ARB_LIBRARIES "${ARB_LIBRARIES}" PARENT_SCOPE)
 endif()

--- a/miniapp/CMakeLists.txt
+++ b/miniapp/CMakeLists.txt
@@ -8,10 +8,10 @@ set(MINIAPP_SOURCES
 
 add_executable(miniapp.exe ${MINIAPP_SOURCES})
 
-target_link_libraries(miniapp.exe LINK_PUBLIC ${NESTMC_LIBRARIES})
+target_link_libraries(miniapp.exe LINK_PUBLIC ${ARB_LIBRARIES})
 target_link_libraries(miniapp.exe LINK_PUBLIC ${EXTERNAL_LIBRARIES})
 
-if(NMC_WITH_MPI)
+if(ARB_WITH_MPI)
     target_link_libraries(miniapp.exe LINK_PUBLIC ${MPI_C_LIBRARIES})
     set_property(TARGET miniapp.exe APPEND_STRING PROPERTY LINK_FLAGS "${MPI_C_LINK_FLAGS}")
 endif()

--- a/miniapp/README.md
+++ b/miniapp/README.md
@@ -1,6 +1,6 @@
-# NEST MC miniapp
+# Arbor miniapp
 
-The miniapp is a simple benchmark of the NEST MC framework.
+The miniapp is a simple benchmark for the Arbor library.
 
 ## the model
 

--- a/miniapp/io.cpp
+++ b/miniapp/io.cpp
@@ -122,7 +122,7 @@ cl_options read_options(int argc, char** argv, bool allow_write) {
     try {
         cl_options defopts;
 
-        CustomCmdLine cmd("nest mc miniapp harness", "0.1");
+        CustomCmdLine cmd("arbor miniapp harness", "0.1");
 
         TCLAP::ValueArg<std::string> ifile_arg(
             "i", "ifile",

--- a/miniapp/miniapp.cpp
+++ b/miniapp/miniapp.cpp
@@ -193,7 +193,7 @@ int main(int argc, char** argv) {
 
 void banner(hw::node_info nd) {
     std::cout << "==========================================\n";
-    std::cout << "  NestMC miniapp\n";
+    std::cout << "  Arbor miniapp\n";
     std::cout << "  - distributed : " << global_policy::size()
               << " (" << std::to_string(global_policy::kind()) << ")\n";
     std::cout << "  - threads     : " << nd.num_cpu_cores

--- a/modcc/backends/avx2.hpp
+++ b/modcc/backends/avx2.hpp
@@ -77,7 +77,7 @@ struct simd_intrinsics<targetKind::avx2> {
                 tb << "_mm256_exp_pd(";
             }
             else {
-                tb << "arb::multicore::nmc_mm256_exp_pd(";
+                tb << "arb::multicore::arb_mm256_exp_pd(";
             }
             break;
         case tok::log:
@@ -85,7 +85,7 @@ struct simd_intrinsics<targetKind::avx2> {
                 tb << "_mm256_log_pd(";
             }
             else {
-                tb << "arb::multicore::nmc_mm256_log_pd(";
+                tb << "arb::multicore::arb_mm256_log_pd(";
             }
             break;
         default:
@@ -102,7 +102,7 @@ struct simd_intrinsics<targetKind::avx2> {
             tb << "_mm256_pow_pd(";
         }
         else {
-            tb << "arb::multicore::nmc_mm256_pow_pd(";
+            tb << "arb::multicore::arb_mm256_pow_pd(";
         }
 
         emit_operands(tb, arg_emitter(base), arg_emitter(exp));

--- a/scripts/travis/build.sh
+++ b/scripts/travis/build.sh
@@ -44,7 +44,7 @@ cd $build_path
 #
 progress "Configuring with cmake"
 
-cmake_flags="-DNMC_WITH_ASSERTIONS=on -DNMC_THREADING_MODEL=${WITH_THREAD} -DNMC_DISTRIBUTED_MODEL=${WITH_DISTRIBUTED} ${CXX_FLAGS}"
+cmake_flags="-DARB_WITH_ASSERTIONS=on -DARB_THREADING_MODEL=${WITH_THREAD} -DARB_DISTRIBUTED_MODEL=${WITH_DISTRIBUTED} ${CXX_FLAGS}"
 echo "cmake flags: ${cmake_flags}"
 cmake .. ${cmake_flags} || error "unable to configure cmake"
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,30 +38,30 @@ set(CUDA_SOURCES
     backends/gpu/kernels/time_ops.cu
 )
 
-if(NMC_WITH_MPI)
+if(ARB_WITH_MPI)
     set(BASE_SOURCES ${BASE_SOURCES} communication/mpi.cpp)
-elseif(NMC_WITH_DRYRUN)
+elseif(ARB_WITH_DRYRUN)
     set(BASE_SOURCES ${BASE_SOURCES} communication/dryrun_global_policy.cpp)
 endif()
 
-if(NMC_WITH_CTHREAD)
+if(ARB_WITH_CTHREAD)
     set(BASE_SOURCES ${BASE_SOURCES} threading/cthread.cpp)
 endif()
 
-add_library(nestmc ${BASE_SOURCES})
-list(APPEND NESTMC_LIBRARIES nestmc)
+add_library(arbor ${BASE_SOURCES})
+list(APPEND ARB_LIBRARIES arbor)
 
-if(NMC_WITH_CUDA)
-    cuda_add_library(gpu ${CUDA_SOURCES})
-    list(APPEND NESTMC_LIBRARIES gpu)
+if(ARB_WITH_CUDA)
+    cuda_add_library(arborcu ${CUDA_SOURCES})
+    list(APPEND ARB_LIBRARIES arborcu)
 endif()
 
-if (NMC_AUTO_RUN_MODCC_ON_CHANGES)
-    add_dependencies(nestmc build_all_mods)
-    if (NMC_WITH_CUDA)
-        add_dependencies(gpu build_all_gpu_mods)
+if (ARB_AUTO_RUN_MODCC_ON_CHANGES)
+    add_dependencies(arbor build_all_mods)
+    if (ARB_WITH_CUDA)
+        add_dependencies(arborcu build_all_gpu_mods)
     endif()
 endif()
 
-# Make changes to the NMC_LIBRARIES visible to the parent scope.
-set(NESTMC_LIBRARIES "${NESTMC_LIBRARIES}" PARENT_SCOPE)
+# Make changes to the ARB_LIBRARIES visible to the parent scope.
+set(ARB_LIBRARIES "${ARB_LIBRARIES}" PARENT_SCOPE)

--- a/src/backends/fvm.hpp
+++ b/src/backends/fvm.hpp
@@ -34,7 +34,7 @@ struct null_backend: public multicore::backend {
 
 } // namespace arb
 
-#ifdef NMC_HAVE_GPU
+#ifdef ARB_HAVE_GPU
 #include <backends/gpu/fvm.hpp>
 #else
 namespace arb {  namespace gpu {

--- a/src/backends/matrix_storage.md
+++ b/src/backends/matrix_storage.md
@@ -8,9 +8,13 @@ An NxN Hines matrix can be stored compactly with 3 vectors of length N:
   * `p`: the parent index
 Additionally, we often store N*1 vectors that have one value per compartment, e.g. voltage, solution or rhs vectors.
 
-In NestMC multicompartment a single cell has a matrix structure associated with in, that is derived directly from the connections between its constituent compartments. NestMC groups these cells into groups of cells, called `cell_groups`. The matrices for all the cells in a group are packed together 
+In Arbor, a single multicompartment cell has an associated matrix structure
+that is derived directly from the connections between its constituent
+compartments. Arbor groups these cells into groups of cells, called
+`cell_groups`. The matrices for all the cells in a group are packed together 
 
-The matrix packing applies the same packing operation to each vector associated with a matrix, i.e. the `u`, `d`, `p` and solution, voltage vectors.
+The matrix packing applies the same packing operation to each vector associated
+with a matrix, i.e. the `u`, `d`, `p` and solution, voltage vectors.
 
 In this discussion we use a simple example group of matrices to illustrate the storage methods, because an example is more illustrative than a formal description:
   * 7 vectors labeled `{a, b, c, d, e, f, g}`

--- a/src/backends/multicore/intrin.hpp
+++ b/src/backends/multicore/intrin.hpp
@@ -55,24 +55,24 @@ constexpr int exp_bias = 1023;
 constexpr double dsqrth = 0.70710678118654752440;
 
 // Useful constants in vector registers
-const __m256d nmc_m256d_zero = _mm256_set1_pd(0.0);
-const __m256d nmc_m256d_one  = _mm256_set1_pd(1.0);
-const __m256d nmc_m256d_two  = _mm256_set1_pd(2.0);
-const __m256d nmc_m256d_nan  = _mm256_set1_pd(std::numeric_limits<double>::quiet_NaN());
-const __m256d nmc_m256d_inf  = _mm256_set1_pd(std::numeric_limits<double>::infinity());
-const __m256d nmc_m256d_ninf = _mm256_set1_pd(-std::numeric_limits<double>::infinity());
+const __m256d arb_m256d_zero = _mm256_set1_pd(0.0);
+const __m256d arb_m256d_one  = _mm256_set1_pd(1.0);
+const __m256d arb_m256d_two  = _mm256_set1_pd(2.0);
+const __m256d arb_m256d_nan  = _mm256_set1_pd(std::numeric_limits<double>::quiet_NaN());
+const __m256d arb_m256d_inf  = _mm256_set1_pd(std::numeric_limits<double>::infinity());
+const __m256d arb_m256d_ninf = _mm256_set1_pd(-std::numeric_limits<double>::infinity());
 }
 
-static void nmc_mm256_print_pd(__m256d x, const char *name) __attribute__ ((unused));
-static void nmc_mm256_print_epi32(__m128i x, const char *name) __attribute__ ((unused));
-static void nmc_mm256_print_epi64x(__m256i x, const char *name) __attribute__ ((unused));
-static __m256d nmc_mm256_exp_pd(__m256d x) __attribute__ ((unused));
-static __m256d nmc_mm256_subnormal_pd(__m256d x) __attribute__ ((unused));
-static __m256d nmc_mm256_frexp_pd(__m256d x, __m128i *e) __attribute__ ((unused));
-static __m256d nmc_mm256_log_pd(__m256d x) __attribute__ ((unused));
-static __m256d nmc_mm256_pow_pd(__m256d x, __m256d y) __attribute__ ((unused));
+static void arb_mm256_print_pd(__m256d x, const char *name) __attribute__ ((unused));
+static void arb_mm256_print_epi32(__m128i x, const char *name) __attribute__ ((unused));
+static void arb_mm256_print_epi64x(__m256i x, const char *name) __attribute__ ((unused));
+static __m256d arb_mm256_exp_pd(__m256d x) __attribute__ ((unused));
+static __m256d arb_mm256_subnormal_pd(__m256d x) __attribute__ ((unused));
+static __m256d arb_mm256_frexp_pd(__m256d x, __m128i *e) __attribute__ ((unused));
+static __m256d arb_mm256_log_pd(__m256d x) __attribute__ ((unused));
+static __m256d arb_mm256_pow_pd(__m256d x, __m256d y) __attribute__ ((unused));
 
-void nmc_mm256_print_pd(__m256d x, const char *name) {
+void arb_mm256_print_pd(__m256d x, const char *name) {
     double *val = (double *) &x;
     std::cout << name << " = { ";
     for (size_t i = 0; i < 4; ++i) {
@@ -82,7 +82,7 @@ void nmc_mm256_print_pd(__m256d x, const char *name) {
     std::cout << "}\n";
 }
 
-void nmc_mm256_print_epi32(__m128i x, const char *name) {
+void arb_mm256_print_epi32(__m128i x, const char *name) {
     int *val = (int *) &x;
     std::cout << name << " = { ";
     for (size_t i = 0; i < 4; ++i) {
@@ -92,7 +92,7 @@ void nmc_mm256_print_epi32(__m128i x, const char *name) {
     std::cout << "}\n";
 }
 
-void nmc_mm256_print_epi64x(__m256i x, const char *name) {
+void arb_mm256_print_epi64x(__m256i x, const char *name) {
     uint64_t *val = (uint64_t *) &x;
     std::cout << name << " = { ";
     for (size_t i = 0; i < 4; ++i) {
@@ -148,7 +148,7 @@ void nmc_mm256_print_epi64x(__m256i x, const char *name) {
 // the standard library seems not to do that, so we are getting differences
 // compared to std::exp() for large exponents.
 //
-__m256d nmc_mm256_exp_pd(__m256d x) {
+__m256d arb_mm256_exp_pd(__m256d x) {
     __m256d x_orig = x;
 
     __m256d px = _mm256_floor_pd(
@@ -193,8 +193,8 @@ __m256d nmc_mm256_exp_pd(__m256d x) {
 
     // Compute 1 + 2*P(x**2) / (Q(x**2)-P(x**2))
     x = _mm256_div_pd(px, _mm256_sub_pd(qx, px));
-    x = _mm256_add_pd(detail::nmc_m256d_one,
-                      _mm256_mul_pd(detail::nmc_m256d_two, x));
+    x = _mm256_add_pd(detail::arb_m256d_one,
+                      _mm256_mul_pd(detail::arb_m256d_two, x));
 
     // Finally, compute x *= 2**n
     __m256i n64 = _mm256_cvtepi32_epi64(n);
@@ -211,23 +211,23 @@ __m256d nmc_mm256_exp_pd(__m256d x) {
     );
     __m256d is_nan = _mm256_cmp_pd(x_orig, x_orig, 3 /* _CMP_UNORD_Q */ );
 
-    x = _mm256_blendv_pd(x, detail::nmc_m256d_inf, is_large);
-    x = _mm256_blendv_pd(x, detail::nmc_m256d_zero, is_small);
-    x = _mm256_blendv_pd(x, detail::nmc_m256d_nan, is_nan);
+    x = _mm256_blendv_pd(x, detail::arb_m256d_inf, is_large);
+    x = _mm256_blendv_pd(x, detail::arb_m256d_zero, is_small);
+    x = _mm256_blendv_pd(x, detail::arb_m256d_nan, is_nan);
     return x;
 
 }
 
-__m256d nmc_mm256_subnormal_pd(__m256d x) {
+__m256d arb_mm256_subnormal_pd(__m256d x) {
     __m256i x_raw = _mm256_castpd_si256(x);
     __m256i exp_mask = _mm256_set1_epi64x(detail::dexp_mask);
     __m256d x_exp = _mm256_castsi256_pd(_mm256_and_si256(x_raw, exp_mask));
 
     // Subnormals have a zero exponent
-    return _mm256_cmp_pd(x_exp, detail::nmc_m256d_zero, 0 /* _CMP_EQ_OQ */);
+    return _mm256_cmp_pd(x_exp, detail::arb_m256d_zero, 0 /* _CMP_EQ_OQ */);
 }
 
-__m256d nmc_mm256_frexp_pd(__m256d x, __m128i *e) {
+__m256d arb_mm256_frexp_pd(__m256d x, __m128i *e) {
     __m256i exp_mask  = _mm256_set1_epi64x(detail::dexp_mask);
     __m256i mant_mask = _mm256_set1_epi64x(detail::dmant_mask);
 
@@ -252,13 +252,13 @@ __m256d nmc_mm256_frexp_pd(__m256d x, __m128i *e) {
 
     // Treat special cases
     __m256d is_zero = _mm256_cmp_pd(
-        x_orig, detail::nmc_m256d_zero, 0 /* _CMP_EQ_OQ */
+        x_orig, detail::arb_m256d_zero, 0 /* _CMP_EQ_OQ */
     );
     __m256d is_inf = _mm256_cmp_pd(
-        x_orig, detail::nmc_m256d_inf, 0 /* _CMP_EQ_OQ */
+        x_orig, detail::arb_m256d_inf, 0 /* _CMP_EQ_OQ */
     );
     __m256d is_ninf = _mm256_cmp_pd(
-        x_orig, detail::nmc_m256d_ninf, 0 /* _CMP_EQ_OQ */
+        x_orig, detail::arb_m256d_ninf, 0 /* _CMP_EQ_OQ */
     );
     __m256d is_nan = _mm256_cmp_pd(x_orig, x_orig, 3 /* _CMP_UNORD_Q */ );
 
@@ -266,13 +266,13 @@ __m256d nmc_mm256_frexp_pd(__m256d x, __m128i *e) {
     // have already prepared it as a power of 2
     __m256i is_denorm = _mm256_cmpeq_epi64(x_exp, _mm256_set1_epi64x(-1022));
 
-    x = _mm256_blendv_pd(x, detail::nmc_m256d_zero, is_zero);
-    x = _mm256_blendv_pd(x, detail::nmc_m256d_inf, is_inf);
-    x = _mm256_blendv_pd(x, detail::nmc_m256d_ninf, is_ninf);
-    x = _mm256_blendv_pd(x, detail::nmc_m256d_nan, is_nan);
+    x = _mm256_blendv_pd(x, detail::arb_m256d_zero, is_zero);
+    x = _mm256_blendv_pd(x, detail::arb_m256d_inf, is_inf);
+    x = _mm256_blendv_pd(x, detail::arb_m256d_ninf, is_ninf);
+    x = _mm256_blendv_pd(x, detail::arb_m256d_nan, is_nan);
 
     // FIXME: We treat denormalized numbers as zero here
-    x = _mm256_blendv_pd(x, detail::nmc_m256d_zero,
+    x = _mm256_blendv_pd(x, detail::arb_m256d_zero,
                          _mm256_castsi256_pd(is_denorm));
     x_exp = _mm256_blendv_epi8(x_exp, _mm256_set1_epi64x(0), is_denorm);
 
@@ -299,12 +299,12 @@ __m256d nmc_mm256_frexp_pd(__m256d x, __m128i *e) {
 //
 //   ln(1+x) = x - 0.5*x^2 + x^3*P(x)/Q(x)
 //
-__m256d nmc_mm256_log_pd(__m256d x) {
+__m256d arb_mm256_log_pd(__m256d x) {
     __m256d x_orig = x;
     __m128i x_exp;
 
     // x := x', x_exp := g
-    x = nmc_mm256_frexp_pd(x, &x_exp);
+    x = arb_mm256_frexp_pd(x, &x_exp);
 
     // convert x_exp to packed double
     __m256d dx_exp = _mm256_cvtepi32_pd(x_exp);
@@ -320,13 +320,13 @@ __m256d nmc_mm256_log_pd(__m256d x) {
 
     // Precompute both branches
     // 2*x - 1
-    __m256d x2m1 = _mm256_sub_pd(_mm256_add_pd(x, x), detail::nmc_m256d_one);
+    __m256d x2m1 = _mm256_sub_pd(_mm256_add_pd(x, x), detail::arb_m256d_one);
 
     // x - 1
-    __m256d xm1 = _mm256_sub_pd(x, detail::nmc_m256d_one);
+    __m256d xm1 = _mm256_sub_pd(x, detail::arb_m256d_one);
 
     // dx_exp - 1
-    __m256d dx_exp_m1 = _mm256_sub_pd(dx_exp, detail::nmc_m256d_one);
+    __m256d dx_exp_m1 = _mm256_sub_pd(dx_exp, detail::arb_m256d_one);
 
     x = _mm256_blendv_pd(xm1, x2m1, lt_sqrth);
     dx_exp = _mm256_blendv_pd(dx_exp, dx_exp_m1, lt_sqrth);
@@ -381,25 +381,25 @@ __m256d nmc_mm256_log_pd(__m256d x) {
 
     // Treat exceptional cases
     __m256d is_inf = _mm256_cmp_pd(
-        x_orig, detail::nmc_m256d_inf, 0 /* _CMP_EQ_OQ */);
+        x_orig, detail::arb_m256d_inf, 0 /* _CMP_EQ_OQ */);
     __m256d is_zero = _mm256_cmp_pd(
-        x_orig, detail::nmc_m256d_zero, 0 /* _CMP_EQ_OQ */);
+        x_orig, detail::arb_m256d_zero, 0 /* _CMP_EQ_OQ */);
     __m256d is_neg = _mm256_cmp_pd(
-        x_orig, detail::nmc_m256d_zero, 17 /* _CMP_LT_OQ */);
-    __m256d is_denorm = nmc_mm256_subnormal_pd(x_orig);
+        x_orig, detail::arb_m256d_zero, 17 /* _CMP_LT_OQ */);
+    __m256d is_denorm = arb_mm256_subnormal_pd(x_orig);
 
-    ret = _mm256_blendv_pd(ret, detail::nmc_m256d_inf, is_inf);
-    ret = _mm256_blendv_pd(ret, detail::nmc_m256d_ninf, is_zero);
+    ret = _mm256_blendv_pd(ret, detail::arb_m256d_inf, is_inf);
+    ret = _mm256_blendv_pd(ret, detail::arb_m256d_ninf, is_zero);
 
     // We treat denormalized cases as zeros
-    ret = _mm256_blendv_pd(ret, detail::nmc_m256d_ninf, is_denorm);
-    ret = _mm256_blendv_pd(ret, detail::nmc_m256d_nan, is_neg);
+    ret = _mm256_blendv_pd(ret, detail::arb_m256d_ninf, is_denorm);
+    ret = _mm256_blendv_pd(ret, detail::arb_m256d_nan, is_neg);
     return ret;
 }
 
 // Equivalent to exp(y*log(x))
-__m256d nmc_mm256_pow_pd(__m256d x, __m256d y) {
-    return nmc_mm256_exp_pd(_mm256_mul_pd(y, nmc_mm256_log_pd(x)));
+__m256d arb_mm256_pow_pd(__m256d x, __m256d y) {
+    return arb_mm256_exp_pd(_mm256_mul_pd(y, arb_mm256_log_pd(x)));
 }
 
 } // end namespace multicore

--- a/src/communication/global_policy.hpp
+++ b/src/communication/global_policy.hpp
@@ -20,9 +20,9 @@ namespace std {
     }
 }
 
-#if defined(NMC_HAVE_MPI)
+#if defined(ARB_HAVE_MPI)
     #include "mpi_global_policy.hpp"
-#elif defined(NMC_HAVE_DRYRUN)
+#elif defined(ARB_HAVE_DRYRUN)
     #include "dryrun_global_policy.hpp"
 #else
     #include "serial_global_policy.hpp"

--- a/src/communication/mpi_global_policy.hpp
+++ b/src/communication/mpi_global_policy.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#ifndef NMC_HAVE_MPI
-#error "mpi_global_policy.hpp should only be compiled in a NMC_HAVE_MPI build"
+#ifndef ARB_HAVE_MPI
+#error "mpi_global_policy.hpp should only be compiled in a ARB_HAVE_MPI build"
 #endif
 
 #include <cstdint>

--- a/src/hardware/gpu.cpp
+++ b/src/hardware/gpu.cpp
@@ -1,11 +1,11 @@
-#ifdef NMC_HAVE_GPU
+#ifdef ARB_HAVE_GPU
     #include <cuda_runtime.h>
 #endif
 
 namespace arb {
 namespace hw {
 
-#ifdef NMC_HAVE_GPU
+#ifdef ARB_HAVE_GPU
 unsigned num_gpus() {
     int n;
     cudaGetDeviceCount(&n);

--- a/src/hardware/memory.cpp
+++ b/src/hardware/memory.cpp
@@ -6,7 +6,7 @@ extern "C" {
 }
 #endif
 
-#ifdef NMC_HAVE_GPU
+#ifdef ARB_HAVE_GPU
     #include <cuda_runtime.h>
 #endif
 
@@ -24,7 +24,7 @@ memory_size_type allocated_memory() {
 }
 #endif
 
-#ifdef NMC_HAVE_GPU
+#ifdef ARB_HAVE_GPU
 memory_size_type gpu_allocated_memory() {
     std::size_t free;
     std::size_t total;

--- a/src/hardware/power.cpp
+++ b/src/hardware/power.cpp
@@ -5,7 +5,7 @@
 namespace arb {
 namespace hw {
 
-#ifdef NMC_HAVE_CRAY
+#ifdef ARB_HAVE_CRAY
 
 energy_size_type energy() {
     energy_size_type result = energy_size_type(-1);

--- a/src/memory/allocator.hpp
+++ b/src/memory/allocator.hpp
@@ -2,7 +2,7 @@
 
 #include <limits>
 
-#ifdef NMC_HAVE_GPU
+#ifdef ARB_HAVE_GPU
 #include <cuda.h>
 #include <cuda_runtime.h>
 #endif
@@ -137,7 +137,7 @@ namespace impl {
     }
 #endif
 
-#ifdef NMC_HAVE_GPU
+#ifdef ARB_HAVE_GPU
     namespace cuda {
         template <size_type Alignment>
         class pinned_policy {
@@ -247,7 +247,7 @@ namespace impl {
             }
         };
     } // namespace cuda
-#endif // #ifdef NMC_HAVE_GPU
+#endif // #ifdef ARB_HAVE_GPU
 } // namespace impl
 
 template<typename T, typename Policy >
@@ -325,7 +325,7 @@ namespace util {
         }
     };
 
-#ifdef NMC_HAVE_GPU
+#ifdef ARB_HAVE_GPU
     template <size_t Alignment>
     struct type_printer<impl::cuda::pinned_policy<Alignment>>{
         static std::string print() {
@@ -371,7 +371,7 @@ template <class T, size_t alignment=(512/8)>
 using hbw_allocator = allocator<T, impl::knl::hbw_policy<alignment>>;
 #endif
 
-#ifdef NMC_HAVE_GPU
+#ifdef ARB_HAVE_GPU
 // For pinned and allocation set the default alignment to correspond to
 // the alignment of 1024 bytes, because pinned memory is allocated at
 // page boundaries. It is allocated at page boundaries (typically 4k),

--- a/src/memory/gpu.hpp
+++ b/src/memory/gpu.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#ifdef NMC_HAVE_GPU
+#ifdef ARB_HAVE_GPU
 
 #include <string>
 #include <cstdint>

--- a/src/memory/host_coordinator.hpp
+++ b/src/memory/host_coordinator.hpp
@@ -11,7 +11,7 @@
 #include "allocator.hpp"
 #include "util.hpp"
 
-#ifdef NMC_HAVE_GPU
+#ifdef ARB_HAVE_GPU
 #include "gpu.hpp"
 #endif
 
@@ -22,7 +22,7 @@ namespace memory {
 template <typename T, class Allocator>
 class host_coordinator;
 
-#ifdef NMC_HAVE_GPU
+#ifdef ARB_HAVE_GPU
 template <typename T, class Allocator>
 class device_coordinator;
 #endif
@@ -123,7 +123,7 @@ public:
         std::copy(from.begin(), from.end(), to.begin());
     }
 
-#ifdef NMC_HAVE_GPU
+#ifdef ARB_HAVE_GPU
     // copy memory from device to host
     template <class Alloc>
     void copy(

--- a/src/memory/memory.hpp
+++ b/src/memory/memory.hpp
@@ -6,7 +6,7 @@
 #include "definitions.hpp"
 #include "host_coordinator.hpp"
 
-#ifdef NMC_HAVE_GPU
+#ifdef ARB_HAVE_GPU
 #include "device_coordinator.hpp"
 #endif
 
@@ -28,7 +28,7 @@ std::ostream& operator<< (std::ostream& o, host_view<T> const& v) {
     return o;
 }
 
-#ifdef NMC_HAVE_GPU
+#ifdef ARB_HAVE_GPU
 // specialization for pinned vectors. Use a host_coordinator, because memory is
 // in the host memory space, and all of the helpers (copy, set, etc) are the
 // same with and without page locked memory

--- a/src/memory/wrappers.hpp
+++ b/src/memory/wrappers.hpp
@@ -5,7 +5,7 @@
 
 #include <memory/memory.hpp>
 
-#ifdef NMC_HAVE_GPU
+#ifdef ARB_HAVE_GPU
 #include <cuda.h>
 #include <cuda_runtime.h>
 #endif
@@ -95,7 +95,7 @@ namespace util {
         return is_on_host<typename std::decay<T>::type>::value;
     }
 
-    #ifdef NMC_HAVE_GPU
+    #ifdef ARB_HAVE_GPU
     template <typename T>
     struct is_on_gpu : std::false_type {};
 
@@ -131,7 +131,7 @@ auto on_host(const C& c) -> decltype(make_const_view(c)) {
     return make_const_view(c);
 }
 
-#ifdef NMC_HAVE_GPU
+#ifdef ARB_HAVE_GPU
 template <
     typename C,
     typename = typename std::enable_if<util::is_on_gpu_v<C>()>::type

--- a/src/profiling/profiler.cpp
+++ b/src/profiling/profiler.cpp
@@ -1,6 +1,6 @@
 #include <numeric>
 
-#ifdef NMC_HAVE_GPU
+#ifdef ARB_HAVE_GPU
     #include <cuda_profiler_api.h>
 #endif
 
@@ -18,7 +18,7 @@ namespace util {
 // a program control which parts of the program are to be profiled. It is a
 // simple wrapper around the API calls with a mutex to ensure correct behaviour
 // when multiple threads attempt to start or stop the profiler.
-#ifdef NMC_HAVE_GPU
+#ifdef ARB_HAVE_GPU
 namespace gpu {
     bool is_running_nvprof = false;
     std::mutex gpu_profiler_mutex;
@@ -298,7 +298,7 @@ profiler_node profiler::performance_tree() {
 }
 
 
-#ifdef NMC_HAVE_PROFILING
+#ifdef ARB_HAVE_PROFILING
 namespace data {
     profiler_wrapper profilers_(profiler("root"));
 }

--- a/src/profiling/profiler.hpp
+++ b/src/profiling/profiler.hpp
@@ -202,7 +202,7 @@ private:
     region_type* current_region_ = &root_region_;
 };
 
-#ifdef NMC_HAVE_PROFILING
+#ifdef ARB_HAVE_PROFILING
 namespace data {
     using profiler_wrapper = arb::threading::enumerable_thread_specific<profiler>;
     extern profiler_wrapper profilers_;
@@ -225,7 +225,7 @@ void profiler_enter(const char* n);
 /// enter nested profiler regions in a single call
 template <class...Args>
 void profiler_enter(const char* n, Args... args) {
-#ifdef NMC_HAVE_PROFILING
+#ifdef ARB_HAVE_PROFILING
     get_profiler().enter(n);
     profiler_enter(args...);
 #endif

--- a/src/threading/cthread.hpp
+++ b/src/threading/cthread.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#if !defined(NMC_HAVE_CTHREAD)
-    #error "this header can only be loaded if NMC_HAVE_CTHREAD is set"
+#if !defined(ARB_HAVE_CTHREAD)
+    #error "this header can only be loaded if ARB_HAVE_CTHREAD is set"
 #endif
 
 // task_group definition

--- a/src/threading/serial.hpp
+++ b/src/threading/serial.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#if !defined(NMC_HAVE_SERIAL)
-    #error "this header can only be loaded if NMC_HAVE_SERIAL is set"
+#if !defined(ARB_HAVE_SERIAL)
+    #error "this header can only be loaded if ARB_HAVE_SERIAL is set"
 #endif
 
 #include <algorithm>

--- a/src/threading/tbb.hpp
+++ b/src/threading/tbb.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#if !defined(NMC_HAVE_TBB)
-    #error this header can only be loaded if NMC_HAVE_TBB is set
+#if !defined(ARB_HAVE_TBB)
+    #error this header can only be loaded if ARB_HAVE_TBB is set
 #endif
 
 #include <string>

--- a/src/threading/threading.cpp
+++ b/src/threading/threading.cpp
@@ -13,27 +13,27 @@ namespace threading {
 
 // Test environment variables for user-specified count of threads.
 //
-// NMC_NUM_THREADS is used if set, otherwise OMP_NUM_THREADS is used.
+// ARB_NUM_THREADS is used if set, otherwise OMP_NUM_THREADS is used.
 //
 // If neither variable is set, returns no value.
 //
 // Valid values for the environment variable are:
-//  0 : NestMC is responsible for picking the number of threads.
+//  0 : Arbor is responsible for picking the number of threads.
 //  >0: The number of threads to use.
 //
 // Throws std::runtime_error:
-//  NMC_NUM_THREADS or OMP_NUM_THREADS is set with invalid value.
+//  ARB_NUM_THREADS or OMP_NUM_THREADS is set with invalid value.
 util::optional<size_t> get_env_num_threads() {
     const char* str;
 
     // select variable to use:
-    //   If NMC_NUM_THREADS_VAR is set, use $NMC_NUM_THREADS_VAR
-    //   else if NMC_NUM_THREAD set, use it
+    //   If ARB_NUM_THREADS_VAR is set, use $ARB_NUM_THREADS_VAR
+    //   else if ARB_NUM_THREAD set, use it
     //   else if OMP_NUM_THREADS set, use it
-    if (auto nthreads_var_name = std::getenv("NMC_NUM_THREADS_VAR")) {
+    if (auto nthreads_var_name = std::getenv("ARB_NUM_THREADS_VAR")) {
         str = std::getenv(nthreads_var_name);
     }
-    else if (! (str = std::getenv("NMC_NUM_THREADS"))) {
+    else if (! (str = std::getenv("ARB_NUM_THREADS"))) {
         str = std::getenv("OMP_NUM_THREADS");
     }
 
@@ -71,7 +71,7 @@ size_t num_threads_init() {
 //      number of threads.
 size_t num_threads() {
     // TODO: this is a bit of a hack until we have user-configurable threading.
-#if defined(NMC_HAVE_SERIAL)
+#if defined(ARB_HAVE_SERIAL)
     return 1;
 #else
     static size_t num_threads_cached = num_threads_init();

--- a/src/threading/threading.hpp
+++ b/src/threading/threading.hpp
@@ -7,13 +7,13 @@ namespace threading {
 
 // Test environment variables for user-specified count of threads.
 // Potential environment variables are tested in this order:
-//   1. use the environment variable specified by NMC_NUM_THREADS_VAR
-//   2. use NMC_NUM_THREADS
+//   1. use the environment variable specified by ARB_NUM_THREADS_VAR
+//   2. use ARB_NUM_THREADS
 //   3. use OMP_NUM_THREADS
 //   4. If no variable is set, returns no value.
 //
 // Valid values for the environment variable are:
-//      0 : NestMC is responsible for picking the number of threads.
+//      0 : Arbor is responsible for picking the number of threads.
 //     >0 : The number of threads to use.
 //
 // Throws std::runtime_error:
@@ -25,11 +25,11 @@ size_t num_threads();
 } // namespace threading
 } // namespace arb
 
-#if defined(NMC_HAVE_TBB)
+#if defined(ARB_HAVE_TBB)
     #include "tbb.hpp"
-#elif defined(NMC_HAVE_CTHREAD)
+#elif defined(ARB_HAVE_CTHREAD)
     #include "cthread.hpp"
 #else
-    #define NMC_HAVE_SERIAL
+    #define ARB_HAVE_SERIAL
     #include "serial.hpp"
 #endif

--- a/src/util/config.hpp
+++ b/src/util/config.hpp
@@ -23,13 +23,13 @@ constexpr bool has_memory_measurement = true;
 constexpr bool has_memory_measurement = false;
 #endif
 
-#ifdef NMC_HAVE_CRAY
+#ifdef ARB_HAVE_CRAY
 constexpr bool has_power_measurement = true;
 #else
 constexpr bool has_power_measurement = false;
 #endif
 
-#ifdef NMC_HAVE_GPU
+#ifdef ARB_HAVE_GPU
 constexpr bool has_cuda = true;
 #else
 constexpr bool has_cuda = false;

--- a/src/util/debug.hpp
+++ b/src/util/debug.hpp
@@ -97,13 +97,13 @@ impl::sepval<Seq, Separator> sepval(const Seq& seq, Separator sep) {
 } // namespace util
 } // namespace arb
 
-#ifdef NMC_HAVE_TRACE
+#ifdef ARB_HAVE_TRACE
     #define TRACE(vars...) arb::util::debug_emit_trace(__FILE__, __LINE__, #vars, ##vars)
 #else
     #define TRACE(...)
 #endif
 
-#ifdef NMC_HAVE_ASSERTIONS
+#ifdef ARB_HAVE_ASSERTIONS
     #ifdef __GNUC__
         #define DEBUG_FUNCTION_NAME __PRETTY_FUNCTION__
     #else
@@ -116,4 +116,4 @@ impl::sepval<Seq, Separator> sepval(const Seq& seq, Separator sep) {
 #else
     #define EXPECTS(condition) \
        (void)(false && (condition))
-#endif // def NMC_HAVE_ASSERTIONS
+#endif // def ARB_HAVE_ASSERTIONS

--- a/src/util/range.hpp
+++ b/src/util/range.hpp
@@ -26,7 +26,7 @@
 #include <type_traits>
 #include <utility>
 
-#ifdef NMC_HAVE_TBB
+#ifdef ARB_HAVE_TBB
 #include <tbb/tbb_stddef.h>
 #endif
 
@@ -108,7 +108,7 @@ struct range {
         return (*this)[n];
     }
 
-#ifdef NMC_HAVE_TBB
+#ifdef ARB_HAVE_TBB
     template <
         typename V = iterator,
         typename = enable_if_t<is_forward_iterator<V>::value>

--- a/tests/global_communication/CMakeLists.txt
+++ b/tests/global_communication/CMakeLists.txt
@@ -16,10 +16,10 @@ add_executable(global_communication.exe ${COMMUNICATION_SOURCES} ${HEADERS})
 set(TARGETS global_communication.exe)
 
 foreach(target ${TARGETS})
-    target_link_libraries(${target} LINK_PUBLIC nestmc gtest)
+    target_link_libraries(${target} LINK_PUBLIC arbor gtest)
     target_link_libraries(${target} LINK_PUBLIC ${EXTERNAL_LIBRARIES})
 
-    if(NMC_WITH_MPI)
+    if(ARB_WITH_MPI)
         target_link_libraries(${target} LINK_PUBLIC ${MPI_C_LIBRARIES})
         set_property(TARGET ${target} APPEND_STRING PROPERTY LINK_FLAGS "${MPI_C_LINK_FLAGS}")
     endif()

--- a/tests/global_communication/test_communicator.cpp
+++ b/tests/global_communication/test_communicator.cpp
@@ -38,7 +38,7 @@ TEST(communicator, policy_basics) {
 //
 // Here we defined proxy types for testing the gather_spikes functionality.
 // These are a little bit simpler than the spike and source types used inside
-// NestMC, to simplify the testing.
+// Arbor, to simplify the testing.
 
 // Proxy for a spike source, which represents gid as an integer.
 struct source_proxy {

--- a/tests/global_communication/test_mpi.cpp
+++ b/tests/global_communication/test_mpi.cpp
@@ -1,4 +1,4 @@
-#ifdef NMC_HAVE_MPI
+#ifdef ARB_HAVE_MPI
 
 #include "../gtest.h"
 
@@ -145,4 +145,4 @@ TEST(mpi, gather) {
     }
 }
 
-#endif // NMC_HAVE_MPI
+#endif // ARB_HAVE_MPI

--- a/tests/performance/io/CMakeLists.txt
+++ b/tests/performance/io/CMakeLists.txt
@@ -7,10 +7,10 @@ set(DISK_IO_SOURCES
 
 add_executable(disk_io.exe ${DISK_IO_SOURCES} ${HEADERS})
 
-target_link_libraries(disk_io.exe LINK_PUBLIC nestmc)
+target_link_libraries(disk_io.exe LINK_PUBLIC arbor)
 target_link_libraries(disk_io.exe LINK_PUBLIC ${EXTERNAL_LIBRARIES})
 
-if(NMC_WITH_MPI)
+if(ARB_WITH_MPI)
     target_link_libraries(disk_io.exe LINK_PUBLIC ${MPI_C_LIBRARIES})
     set_property(TARGET disk_io.exe APPEND_STRING PROPERTY LINK_FLAGS "${MPI_C_LINK_FLAGS}")
 endif()

--- a/tests/ubench/CMakeLists.txt
+++ b/tests/ubench/CMakeLists.txt
@@ -69,14 +69,14 @@ foreach(bench_src ${bench_sources})
 endforeach()
 
 
-if(NMC_WITH_CUDA)
+if(ARB_WITH_CUDA)
     cuda_include_directories("${gbench_install_dir}/include")
     foreach(bench_src ${bench_sources_cuda})
         string(REGEX REPLACE "\\.[^.]*$" "" bench_exe "${bench_src}")
         cuda_add_executable("${bench_exe}" EXCLUDE_FROM_ALL "${bench_src}")
         add_dependencies("${bench_exe}" gbench)
         target_link_libraries("${bench_exe}" "${gbench_install_dir}/lib/libbenchmark.a")
-        target_link_libraries("${bench_exe}" LINK_PUBLIC ${NESTMC_LIBRARIES})
+        target_link_libraries("${bench_exe}" LINK_PUBLIC ${ARB_LIBRARIES})
 
         list(APPEND bench_exe_list ${bench_exe})
     endforeach()

--- a/tests/ubench/README.md
+++ b/tests/ubench/README.md
@@ -126,11 +126,15 @@ Platform:
 
 #### Motivation
 
-The reduction by key pattern with repeated keys is used when "point process" mechanism contributions to currents are collected.
-More than one point process, typically synapses, can be attached to a compartment,
-and when their contributions are computed and added to the per-compartment current in parallel, care must be taken to avoid race conditions.
-Early versions of NestMC used cuda atomic operations to perform the accumulation, which works quite well up to a certain point.
-However, performance with atomics decreases as the number of synapses per compartment increases, i.e. as the number of threads performing simultatneous atomic updates on the same location increases.
+The reduction by key pattern with repeated keys is used when "point process"
+mechanism contributions to currents are collected. More than one point process,
+typically synapses, can be attached to a compartment, and when their
+contributions are computed and added to the per-compartment current in
+parallel, care must be taken to avoid race conditions. Early versions of Arbor
+used cuda atomic operations to perform the accumulation, which works quite well
+up to a certain point. However, performance with atomics decreases as the
+number of synapses per compartment increases, i.e. as the number of threads
+performing simultatneous atomic updates on the same location increases.
 
 #### Implementations
 
@@ -153,11 +157,15 @@ Platform:
 * gcc version 5.2.0
 * nvcc version 8.0.61
 
-Results are presented as speedup for warp intrinsics vs atomics, for both single and double precision.
-Note that the P100 GPU has hardware support for double precision atomics, and we expect much larger speedup for double precision on Keplar GPUs that emulate double precision atomics with CAS.
-The benchmark updates `n` locations, each with an average density of `d` keys per location.
-This is equivalent to `n` compartments with `d` synapses per compartment.
-Atomics are faster for the case where both `n` and `d` are small, however the gpu is backend is for throughput simulations, with large cell groups with at least 10k compartments in total.
+Results are presented as speedup for warp intrinsics vs atomics, for both
+single and double precision. Note that the P100 GPU has hardware support for
+double precision atomics, and we expect much larger speedup for double
+precision on Keplar GPUs that emulate double precision atomics with CAS. The
+benchmark updates `n` locations, each with an average density of `d` keys per
+location. This is equivalent to `n` compartments with `d` synapses per
+compartment. Atomics are faster for the case where both `n` and `d` are small,
+however the gpu is backend is for throughput simulations, with large cell
+groups with at least 10k compartments in total.
 
 *float*
 

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -87,7 +87,7 @@ set(TEST_SOURCES
     stats.cpp
 )
 
-if(NMC_VECTORIZE_TARGET STREQUAL "AVX2")
+if(ARB_VECTORIZE_TARGET STREQUAL "AVX2")
     list(APPEND TEST_SOURCES test_intrin.cpp)
 endif()
 
@@ -96,23 +96,23 @@ set(TARGETS test.exe)
 add_executable(test.exe ${TEST_SOURCES})
 target_compile_definitions(test.exe PUBLIC "-DDATADIR=\"${PROJECT_SOURCE_DIR}/data\"")
 
-if (NMC_AUTO_RUN_MODCC_ON_CHANGES)
+if (ARB_AUTO_RUN_MODCC_ON_CHANGES)
   add_dependencies(test.exe build_test_mods)
 endif()
 
 target_include_directories(test.exe PRIVATE "${mech_proto_dir}/..")
 
-if(NMC_WITH_CUDA)
+if(ARB_WITH_CUDA)
     set(TARGETS ${TARGETS} test_cuda.exe)
     cuda_add_executable(test_cuda.exe ${TEST_CUDA_SOURCES})
 endif()
 
 foreach(target ${TARGETS})
     target_link_libraries(${target} LINK_PUBLIC gtest)
-    target_link_libraries(${target} LINK_PUBLIC ${NESTMC_LIBRARIES})
+    target_link_libraries(${target} LINK_PUBLIC ${ARB_LIBRARIES})
     target_link_libraries(${target} LINK_PUBLIC ${EXTERNAL_LIBRARIES})
 
-    if(NMC_WITH_MPI)
+    if(ARB_WITH_MPI)
         target_link_libraries(${target} LINK_PUBLIC ${MPI_C_LIBRARIES})
         set_property(TARGET ${target} APPEND_STRING PROPERTY LINK_FLAGS "${MPI_C_LINK_FLAGS}")
     endif()

--- a/tests/unit/test_intrin.cpp
+++ b/tests/unit/test_intrin.cpp
@@ -32,7 +32,7 @@ TEST(intrin, exp256) {
 
 
     for (size_t i = 0; i < 16/simd_len; ++i) {
-        __m256d vv = nmc_mm256_exp_pd(vvalues[i]);
+        __m256d vv = arb_mm256_exp_pd(vvalues[i]);
         double *intrin = (double *) &vv;
         for (size_t j = 0; j < simd_len; ++j) {
             double v = values[i*simd_len + j];
@@ -59,7 +59,7 @@ TEST(intrin, frexp256) {
 
     for (size_t i = 0; i < 16/simd_len; ++i) {
         __m128i vexp;
-        __m256d vbase = nmc_mm256_frexp_pd(vvalues[i], &vexp);
+        __m256d vbase = arb_mm256_frexp_pd(vvalues[i], &vexp);
         double *vbase_ = (double *) &vbase;
         int    *vexp_  = (int *) &vexp;
         for (size_t j = 0; j < simd_len; ++j) {
@@ -99,7 +99,7 @@ TEST(intrin, log256) {
 
 
     for (size_t i = 0; i < 16/simd_len; ++i) {
-        __m256d vv = nmc_mm256_log_pd(vvalues[i]);
+        __m256d vv = arb_mm256_log_pd(vvalues[i]);
         double *intrin = (double *) &vv;
         for (size_t j = 0; j < simd_len; ++j) {
             double v = values[i*simd_len + j];

--- a/tests/unit/test_range.cpp
+++ b/tests/unit/test_range.cpp
@@ -9,7 +9,7 @@
 #include <type_traits>
 #include <unordered_map>
 
-#ifdef NMC_HAVE_TBB
+#ifdef ARB_HAVE_TBB
 #include <tbb/tbb_stddef.h>
 #endif
 
@@ -600,7 +600,7 @@ TEST(range, is_sorted_by) {
     EXPECT_TRUE(util::is_sorted_by(seq, [](int x) { return x+2; }, std::greater<int>{}));
 }
 
-#ifdef NMC_HAVE_TBB
+#ifdef ARB_HAVE_TBB
 
 TEST(range, tbb_split) {
     constexpr std::size_t N = 20;

--- a/tests/validation/CMakeLists.txt
+++ b/tests/validation/CMakeLists.txt
@@ -14,21 +14,21 @@ set(VALIDATION_SOURCES
     validate.cpp
 )
 
-if(NMC_VALIDATION_DATA_DIR)
+if(ARB_VALIDATION_DATA_DIR)
     if ("${CMAKE_VERSION}" MATCHES "^3.[789].")
-        message(WARNING "CMake ${CMAKE_VERSION} has broken FindCUDA; omitting NMC_DATADIR define.")
+        message(WARNING "CMake ${CMAKE_VERSION} has broken FindCUDA; omitting ARB_DATADIR define.")
     else()
-        add_definitions("-DNMC_DATADIR=\"${NMC_VALIDATION_DATA_DIR}\"")
+        add_definitions("-DARB_DATADIR=\"${ARB_VALIDATION_DATA_DIR}\"")
     endif()
 endif()
 
 add_executable(validate.exe ${VALIDATION_SOURCES})
 
 target_link_libraries(validate.exe LINK_PUBLIC gtest)
-target_link_libraries(validate.exe LINK_PUBLIC ${NESTMC_LIBRARIES})
+target_link_libraries(validate.exe LINK_PUBLIC ${ARB_LIBRARIES})
 target_link_libraries(validate.exe LINK_PUBLIC ${EXTERNAL_LIBRARIES})
 
-if(NMC_WITH_MPI)
+if(ARB_WITH_MPI)
     target_link_libraries(validate.exe LINK_PUBLIC ${MPI_C_LIBRARIES})
     set_property(TARGET validate.exe APPEND_STRING PROPERTY LINK_FLAGS "${MPI_C_LINK_FLAGS}")
 endif()
@@ -39,6 +39,6 @@ set_target_properties(
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests"
 )
 
-if(NMC_BUILD_VALIDATION_DATA)
+if(ARB_BUILD_VALIDATION_DATA)
     add_dependencies(validate.exe validation_data)
 endif()

--- a/tests/validation/validate.cpp
+++ b/tests/validation/validate.cpp
@@ -26,10 +26,10 @@ const char* usage_str =
 "  -h, --help          Display usage information and exit\n"
 "\n"
 "Validation data is searched by default in the directory specified by\n"
-"NMC_DATADIR at compile time. If NMC_DATADIR does not correspond to a\n"
+"ARB_DATADIR at compile time. If ARB_DATADIR does not correspond to a\n"
 "directory, the tests will try the paths './validation/data' and\n"
 "'../validation/data'. This default path can be overridden with the\n"
-"NMC_DATADIR environment variable, or with the -p command-line option.\n";
+"ARB_DATADIR environment variable, or with the -p command-line option.\n";
 
 int main(int argc, char **argv) {
     using to::parse_opt;

--- a/tests/validation/validate_ball_and_stick.cpp
+++ b/tests/validation/validate_ball_and_stick.cpp
@@ -48,7 +48,7 @@ void run_ncomp_convergence_test(
         {"name", "membrane voltage"},
         {"model", model_name},
         {"dt", dt},
-        {"sim", "nestmc"},
+        {"sim", "arbor"},
         {"units", "mV"},
         {"backend_kind", to_string(backend)}
     };

--- a/tests/validation/validate_kinetic.cpp
+++ b/tests/validation/validate_kinetic.cpp
@@ -35,7 +35,7 @@ void run_kinetic_dt(
     rec.add_probe(0, 0, cell_probe_address{{0, 0.5}, cell_probe_address::membrane_voltage});
     probe_label plabels[1] = {"soma.mid", {0u, 0u}};
 
-    meta["sim"] = "nestmc";
+    meta["sim"] = "arbor";
     meta["backend_kind"] = to_string(backend);
 
     convergence_test_runner<float> runner("dt", plabels, meta);

--- a/tests/validation/validate_soma.cpp
+++ b/tests/validation/validate_soma.cpp
@@ -38,7 +38,7 @@ void validate_soma(backend_kind backend) {
     nlohmann::json meta = {
         {"name", "membrane voltage"},
         {"model", "soma"},
-        {"sim", "nestmc"},
+        {"sim", "arbor"},
         {"units", "mV"},
         {"backend_kind", to_string(backend)}
     };

--- a/tests/validation/validate_synapses.cpp
+++ b/tests/validation/validate_synapses.cpp
@@ -32,7 +32,7 @@ void run_synapse_test(
     nlohmann::json meta = {
         {"name", "membrane voltage"},
         {"model", syn_type},
-        {"sim", "nestmc"},
+        {"sim", "arbor"},
         {"units", "mV"},
         {"backend_kind", to_string(backend)}
     };

--- a/tests/validation/validation_data.cpp
+++ b/tests/validation/validation_data.cpp
@@ -15,23 +15,23 @@ namespace arb {
 
 trace_io g_trace_io;
 
-#ifndef NMC_DATADIR
-#define NMC_DATADIR ""
+#ifndef ARB_DATADIR
+#define ARB_DATADIR ""
 #endif
 
 util::path trace_io::find_datadir() {
     // If environment variable is set, use that in preference.
 
-    if (const char* env_path = std::getenv("NMC_DATADIR")) {
+    if (const char* env_path = std::getenv("ARB_DATADIR")) {
         return util::path(env_path);
     }
 
-    // Otherwise try compile-time path NMC_DATADIR and hard-coded
+    // Otherwise try compile-time path ARB_DATADIR and hard-coded
     // relative paths below in turn, returning the first that
     // corresponds to an existing directory.
 
     const char* paths[] = {
-        NMC_DATADIR,
+        ARB_DATADIR,
         "./validation/data",
         "../validation/data"
     };

--- a/tests/validation/validation_data.hpp
+++ b/tests/validation/validation_data.hpp
@@ -88,9 +88,9 @@ private:
     float min_dt_ = 0.001f;
     float sample_dt_ = 0.005f;
 
-    // Returns value of NMC_DATADIR environment variable if set,
+    // Returns value of ARB_DATADIR environment variable if set,
     // otherwise make a 'best-effort' search for the data directory,
-    // starting with NMC_DATADIR preprocessor define if defined and
+    // starting with ARB_DATADIR preprocessor define if defined and
     // if the directory exists, or else try './validation/data'
     // and '../validation/data'.
     static util::path find_datadir();

--- a/validation/CMakeLists.txt
+++ b/validation/CMakeLists.txt
@@ -28,7 +28,7 @@ endfunction()
 include(CMakeParseArguments)
 function(add_validation_data)
     cmake_parse_arguments(ADD_VALIDATION_DATA "" "OUTPUT" "DEPENDS;COMMAND" ${ARGN})
-    set(out "${NMC_VALIDATION_DATA_DIR}/${ADD_VALIDATION_DATA_OUTPUT}")
+    set(out "${ARB_VALIDATION_DATA_DIR}/${ADD_VALIDATION_DATA_OUTPUT}")
     string(REGEX REPLACE "([^;]+)" "${CMAKE_CURRENT_SOURCE_DIR}/\\1" deps "${ADD_VALIDATION_DATA_DEPENDS}")
     add_custom_command(
         OUTPUT "${out}"
@@ -43,7 +43,7 @@ function(add_validation_data)
 endfunction()
 
 
-if(NMC_BUILD_NRN_VALIDATION_DATA)
+if(ARB_BUILD_NRN_VALIDATION_DATA)
     add_subdirectory(ref/neuron)
 endif()
 

--- a/validation/ref/numeric/CMakeLists.txt
+++ b/validation/ref/numeric/CMakeLists.txt
@@ -1,6 +1,6 @@
 # note: function add_validation_data defined in validation/CMakeLists.txt
 
-if(NMC_BUILD_JULIA_VALIDATION_DATA)
+if(ARB_BUILD_JULIA_VALIDATION_DATA)
     add_validation_data(
         OUTPUT numeric_kin1.json
         DEPENDS numeric_kin1.jl

--- a/validation/ref/numeric/numeric_rallpack1.jl
+++ b/validation/ref/numeric/numeric_rallpack1.jl
@@ -14,7 +14,7 @@ function run_cable(x_prop, ts)
     # Physical properties:
 
     # f is a fudge factor. rM needs to be the same
-    # the same as in nestmc, where we cannot yet set
+    # the same as in arbor, where we cannot yet set
     # the membrane conductance parameter. Scaling
     # other parameters proportionally, however,
     # gives the same dynamics.


### PR DESCRIPTION
* Use ARB_ and arb_ as variable prefixes in place of NMC_ and nmc_.
* Replace references to 'NestMC' and 'NEST MC' to refer instead to Arbor.
* Use 'arbor' as the sim name in generated validation data.
* Reflow long-line paragraphs in `tests/ubench/README.md`.
* Change names of CUDA mechanism and CUDA kernel libraries to include arbor name.