### PR TITLE
Move event wrangling from cell_group to model

### DIFF
--- a/src/cell_group.hpp
+++ b/src/cell_group.hpp
@@ -12,36 +12,21 @@
 #include <sampling.hpp>
 #include <schedule.hpp>
 #include <spike.hpp>
-#include <util/rangeutil.hpp>
 
 namespace arb {
 
 class cell_group {
 public:
+    using event_lane_subrange = util::subrange_view_type<std::vector<std::vector<postsynaptic_spike_event>>>;
+
     virtual ~cell_group() = default;
 
     virtual cell_kind get_cell_kind() const = 0;
 
     virtual void reset() = 0;
     virtual void set_binning_policy(binning_kind policy, time_type bin_interval) = 0;
-    virtual void advance(epoch epoch, time_type dt) = 0;
+    virtual void advance(epoch epoch, time_type dt, const event_lane_subrange& events) = 0;
 
-    // Pass events to be delivered to targets in the cell group in a future epoch.
-    // events:
-    //    An unsorted vector of post-synaptic events is maintained for each gid
-    //    on the local domain. These event lists are stored in a vector, with one
-    //    entry for each gid. Event lists for a cell group are contiguous in the
-    //    vector, in same order that input gid were provided to the cell_group
-    //    constructor.
-    // tfinal:
-    //    The final time for the current integration epoch. This may be used
-    //    by the cell_group implementation to omptimise event queue wrangling.
-    // epoch:
-    //    The current integration epoch. Events in events are due for delivery
-    //    in epoch+1 and later.
-    virtual void enqueue_events(
-            epoch epoch,
-            util::subrange_view_type<std::vector<std::vector<postsynaptic_spike_event>>> events) = 0;
     virtual const std::vector<spike>& spikes() const = 0;
     virtual void clear_spikes() = 0;
 

--- a/src/cell_group.hpp
+++ b/src/cell_group.hpp
@@ -17,8 +17,6 @@ namespace arb {
 
 class cell_group {
 public:
-    using event_lane_subrange = util::subrange_view_type<std::vector<std::vector<postsynaptic_spike_event>>>;
-
     virtual ~cell_group() = default;
 
     virtual cell_kind get_cell_kind() const = 0;

--- a/src/communication/communicator.hpp
+++ b/src/communication/communicator.hpp
@@ -220,6 +220,10 @@ public:
     /// Returns the total number of global spikes over the duration of the simulation
     std::uint64_t num_spikes() const { return num_spikes_; }
 
+    cell_size_type num_local_cells() const {
+        return num_local_cells_;
+    }
+
     const std::vector<connection>& connections() const {
         return connections_;
     }

--- a/src/communication/communicator.hpp
+++ b/src/communication/communicator.hpp
@@ -39,9 +39,6 @@ class communicator {
 public:
     using communication_policy_type = CommunicationPolicy;
 
-    /// per-cell group lists of events to be delivered
-    using event_queue = std::vector<postsynaptic_spike_event>;
-
     communicator() {}
 
     explicit communicator(const recipe& rec, const domain_decomposition& dom_dec) {
@@ -158,12 +155,12 @@ public:
     /// Returns a vector of event queues, with one queue for each local cell group. The
     /// events in each queue are all events that must be delivered to targets in that cell
     /// group as a result of the global spike exchange.
-    std::vector<event_queue> make_event_queues(const gathered_vector<spike>& global_spikes) {
+    std::vector<event_vector> make_event_queues(const gathered_vector<spike>& global_spikes) {
         using util::subrange_view;
         using util::make_span;
         using util::make_range;
 
-        auto queues = std::vector<event_queue>(num_local_cells_);
+        auto queues = std::vector<event_vector>(num_local_cells_);
         const auto& sp = global_spikes.partition();
         const auto& cp = connection_part_;
         for (auto dom: make_span(0, num_domains_)) {

--- a/src/communication/communicator.hpp
+++ b/src/communication/communicator.hpp
@@ -155,12 +155,12 @@ public:
     /// Returns a vector of event queues, with one queue for each local cell group. The
     /// events in each queue are all events that must be delivered to targets in that cell
     /// group as a result of the global spike exchange.
-    std::vector<event_vector> make_event_queues(const gathered_vector<spike>& global_spikes) {
+    std::vector<pse_vector> make_event_queues(const gathered_vector<spike>& global_spikes) {
         using util::subrange_view;
         using util::make_span;
         using util::make_range;
 
-        auto queues = std::vector<event_vector>(num_local_cells_);
+        auto queues = std::vector<pse_vector>(num_local_cells_);
         const auto& sp = global_spikes.partition();
         const auto& cp = connection_part_;
         for (auto dom: make_span(0, num_domains_)) {

--- a/src/dss_cell_group.hpp
+++ b/src/dss_cell_group.hpp
@@ -44,7 +44,7 @@ public:
 
     void set_binning_policy(binning_kind policy, time_type bin_interval) override {}
 
-    void advance(epoch ep, time_type dt) override {
+    void advance(epoch ep, time_type dt, const event_lane_subrange& event_lanes) override {
         for (auto i: util::make_span(0, not_emit_it_.size())) {
             // The first potential spike_time to emit for this cell
             auto spike_time_it = not_emit_it_[i];
@@ -61,10 +61,6 @@ public:
             }
         }
     };
-
-    void enqueue_events(epoch, util::subrange_view_type<std::vector<std::vector<postsynaptic_spike_event>>>) override {
-        std::runtime_error("The dss_cells do not support incoming events!");
-    }
 
     const std::vector<spike>& spikes() const override {
         return spikes_;

--- a/src/event_queue.hpp
+++ b/src/event_queue.hpp
@@ -39,7 +39,8 @@ struct postsynaptic_spike_event {
     }
 };
 
-using event_lane_subrange = util::subrange_view_type<std::vector<std::vector<postsynaptic_spike_event>>>;
+using event_vector = std::vector<postsynaptic_spike_event>;
+using event_lane_subrange = util::subrange_view_type<std::vector<event_vector>>;
 
 template <typename Event>
 class event_queue {

--- a/src/event_queue.hpp
+++ b/src/event_queue.hpp
@@ -7,12 +7,13 @@
 #include <type_traits>
 #include <utility>
 
-#include "common_types.hpp"
-#include "generic_event.hpp"
-#include "util/meta.hpp"
-#include "util/optional.hpp"
-#include "util/range.hpp"
-#include "util/strprintf.hpp"
+#include <common_types.hpp>
+#include <generic_event.hpp>
+#include <util/meta.hpp>
+#include <util/optional.hpp>
+#include <util/range.hpp>
+#include <util/rangeutil.hpp>
+#include <util/strprintf.hpp>
 
 namespace arb {
 
@@ -37,6 +38,8 @@ struct postsynaptic_spike_event {
         return o << "E[tgt " << e.target << ", t " << e.time << ", w " << e.weight << "]";
     }
 };
+
+using event_lane_subrange = util::subrange_view_type<std::vector<postsynaptic_spike_event>>;
 
 template <typename Event>
 class event_queue {

--- a/src/event_queue.hpp
+++ b/src/event_queue.hpp
@@ -39,7 +39,7 @@ struct postsynaptic_spike_event {
     }
 };
 
-using event_lane_subrange = util::subrange_view_type<std::vector<postsynaptic_spike_event>>;
+using event_lane_subrange = util::subrange_view_type<std::vector<std::vector<postsynaptic_spike_event>>>;
 
 template <typename Event>
 class event_queue {

--- a/src/event_queue.hpp
+++ b/src/event_queue.hpp
@@ -29,8 +29,12 @@ struct postsynaptic_spike_event {
     time_type time;
     float weight;
 
-    friend bool operator==(postsynaptic_spike_event l, postsynaptic_spike_event r) {
+    friend bool operator==(const postsynaptic_spike_event& l, const postsynaptic_spike_event& r) {
         return l.target==r.target && l.time==r.time && l.weight==r.weight;
+    }
+
+    friend bool operator<(const postsynaptic_spike_event& l, const postsynaptic_spike_event& r) {
+        return std::tie(l.time, l.target, l.weight) < std::tie(r.time, r.target, r.weight);
     }
 
     friend std::ostream& operator<<(std::ostream& o, const arb::postsynaptic_spike_event& e)
@@ -39,8 +43,8 @@ struct postsynaptic_spike_event {
     }
 };
 
-using event_vector = std::vector<postsynaptic_spike_event>;
-using event_lane_subrange = util::subrange_view_type<std::vector<event_vector>>;
+using pse_vector = std::vector<postsynaptic_spike_event>;
+using event_lane_subrange = util::subrange_view_type<std::vector<pse_vector>>;
 
 template <typename Event>
 class event_queue {

--- a/src/mc_cell_group.hpp
+++ b/src/mc_cell_group.hpp
@@ -94,14 +94,17 @@ public:
 
         PE("event-setup");
         staged_events_.clear();
-        for (auto lid: util::make_span(0, gids_.size())) {
-            auto& lane = event_lanes[lid];
-            for (auto e: lane) {
-                if (e.time>=ep.tfinal) break;
-                e.time = binners_[lid].bin(e.time, tstart);
-                auto h = target_handles_[target_handle_divisions_[lid]+e.target.index];
-                auto ev = deliverable_event(e.time, h, e.weight);
-                staged_events_.push_back(ev);
+        // skip event binning if empty lanes are passed
+        if (event_lanes.size()) {
+            for (auto lid: util::make_span(0, gids_.size())) {
+                auto& lane = event_lanes[lid];
+                for (auto e: lane) {
+                    if (e.time>=ep.tfinal) break;
+                    e.time = binners_[lid].bin(e.time, tstart);
+                    auto h = target_handles_[target_handle_divisions_[lid]+e.target.index];
+                    auto ev = deliverable_event(e.time, h, e.weight);
+                    staged_events_.push_back(ev);
+                }
             }
         }
         PL();

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -14,11 +14,7 @@
 
 namespace arb {
 
-void merge_events(
-    event_vector& events,
-    const event_vector& lc,
-    event_vector& lf,
-    time_type tfinal);
+void merge_events(time_type tfinal, const event_vector& lc, event_vector& events, event_vector& lf);
 
 model::model(const recipe& rec, const domain_decomposition& decomp):
     communicator_(rec, decomp)
@@ -124,10 +120,10 @@ time_type model::run(time_type tfinal, time_type dt) {
             [&](cell_size_type i) {
                 const auto epid = epoch_.id;
                 merge_events(
-                    events[i],
+                    epoch_.tfinal,
                     event_lanes(epid)[i],
-                    event_lanes(epid+1)[i],
-                    epoch_.tfinal);
+                    events[i],
+                    event_lanes(epid+1)[i]);
             });
         PL(2);
 

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -254,20 +254,24 @@ void model::inject_events(const event_vector& events) {
     }
 }
 
-void merge_events(
-    event_vector& events,
-    const event_vector& lc,
-    event_vector& lf,
-    time_type tfinal)
-{
+// Merge events that are to be delivered from two lists into a sorted list.
+// Events are sorted by delivery time, then target, then weight.
+//
+//  tfinal: The time at which the current epoch finishes.
+//  lc: Sorted set of events to be delivered before and after `tfinal`.
+//  events: Unsorted list of events with delivery time greater than or equal to
+//      tfinal. May be modified by the call.
+//  lf: Will hold a list of all postsynaptic events in `events` and `lc` that
+//      have delivery times greater than or equal to `tfinal`.
+void merge_events(time_type tfinal, const event_vector& lc, event_vector& events, event_vector& lf) {
     using pse = postsynaptic_spike_event;
 
     // For ordering events by: delivery time, then target index, then weight.
     auto lex_bind = [](const pse& e){return std::tie(e.time, e.target, e.weight);};
     auto lex_less = [lex_bind] (const pse& l, const pse& r) {return lex_bind(l)<lex_bind(r);};
 
-    // For a cell, merge the incoming events with events in lc that are
-    // not to be delivered in thie epoch, and store the result in lf.
+    // Merge the incoming events with events in lc that are not to be delivered
+    // in this epoch, and store the result in lf.
 
     // STEP 1: sort events in place in events[l]
     PE("sort");

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -37,8 +37,7 @@ model::model(const recipe& rec, const domain_decomposition& decomp):
 
 
     // Create event lane buffers.
-    // There is one set for each epoch: current and next.
-    event_lanes_.resize(2);
+    // There is one set for each epoch: current (0) and next (1).
     // For each epoch there is one lane for each cell in the cell group.
     event_lanes_[0].resize(communicator_.num_local_cells());
     event_lanes_[1].resize(communicator_.num_local_cells());

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -263,7 +263,6 @@ void merge_events(time_type tfinal, const pse_vector& lc, pse_vector& events, ps
 
     // STEP 1: sort events in place in events[l]
     PE("sort");
-    //util::sort_by(events, pse_tie);
     util::sort(events);
     PL();
 

--- a/src/model.hpp
+++ b/src/model.hpp
@@ -59,6 +59,10 @@ public:
     void set_local_spike_callback(spike_export_function export_callback);
 
 private:
+    std::vector<std::vector<postsynaptic_spike_event>>& event_lanes(std::size_t epoch_id);
+
+    void merge_events(std::vector<postsynaptic_spike_event>& events, std::size_t lane);
+
     std::size_t num_groups() const;
 
     // keep track of information about the current integration interval
@@ -93,6 +97,9 @@ private:
 
     local_spike_store_type& current_spikes()  { return local_spikes_.get(); }
     local_spike_store_type& previous_spikes() { return local_spikes_.other(); }
+
+    // Pending events to be delivered.
+    std::vector<std::vector<std::vector<postsynaptic_spike_event>>> event_lanes_;
 
     // Sampler associations handles are managed by a helper class.
     util::handle_set<sampler_association_handle> sassoc_handles_;

--- a/src/model.hpp
+++ b/src/model.hpp
@@ -57,10 +57,10 @@ public:
     // Add events directly to targets.
     // Must be called before calling model::run, and must contain events that
     // are to be delivered at or after the current model time.
-    void inject_events(const event_vector& events);
+    void inject_events(const pse_vector& events);
 
 private:
-    std::vector<event_vector>& event_lanes(std::size_t epoch_id);
+    std::vector<pse_vector>& event_lanes(std::size_t epoch_id);
 
     std::size_t num_groups() const;
 
@@ -99,7 +99,7 @@ private:
     local_spike_store_type& previous_spikes() { return local_spikes_.other(); }
 
     // Pending events to be delivered.
-    std::array<std::vector<event_vector>, 2> event_lanes_;
+    std::array<std::vector<pse_vector>, 2> event_lanes_;
 
     // Sampler associations handles are managed by a helper class.
     util::handle_set<sampler_association_handle> sassoc_handles_;

--- a/src/model.hpp
+++ b/src/model.hpp
@@ -45,23 +45,21 @@ public:
     // Set event binning policy on all our groups.
     void set_binning_policy(binning_kind policy, time_type bin_interval);
 
-    // access cell_group directly
-    // TODO: deprecate. Currently used in some validation tests to inject
-    // events directly into a cell group.
-    cell_group& group(int i);
-
-    // register a callback that will perform a export of the global
-    // spike vector
+    // Register a callback that will perform a export of the global
+    // spike vector.
     void set_global_spike_callback(spike_export_function export_callback);
 
-    // register a callback that will perform a export of the rank local
-    // spike vector
+    // Register a callback that will perform a export of the rank local
+    // spike vector.
     void set_local_spike_callback(spike_export_function export_callback);
 
-private:
-    std::vector<std::vector<postsynaptic_spike_event>>& event_lanes(std::size_t epoch_id);
+    // Add events directly to targets.
+    // Must be called before calling model::run, and must contain events that
+    // are to be delivered at or after the current model time.
+    void inject_events(const event_vector& events);
 
-    void merge_events(std::vector<postsynaptic_spike_event>& events, std::size_t lane);
+private:
+    std::vector<event_vector>& event_lanes(std::size_t epoch_id);
 
     std::size_t num_groups() const;
 
@@ -77,9 +75,10 @@ private:
     spike_export_function global_export_callback_ = util::nop_function;
     spike_export_function local_export_callback_ = util::nop_function;
 
-    // Hash table for looking up the group index of the cell_group that
-    // contains gid
-    std::unordered_map<cell_gid_type, cell_gid_type> gid_groups_;
+    // Hash table for looking up the the local index of a cell with a given gid
+    std::unordered_map<cell_gid_type, cell_size_type> gid_to_local_;
+
+    util::optional<cell_size_type> local_cell_index(cell_gid_type);
 
     communicator_type communicator_;
 
@@ -99,7 +98,7 @@ private:
     local_spike_store_type& previous_spikes() { return local_spikes_.other(); }
 
     // Pending events to be delivered.
-    std::vector<std::vector<std::vector<postsynaptic_spike_event>>> event_lanes_;
+    std::vector<std::vector<event_vector>> event_lanes_;
 
     // Sampler associations handles are managed by a helper class.
     util::handle_set<sampler_association_handle> sassoc_handles_;

--- a/src/model.hpp
+++ b/src/model.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <mutex>
+#include <array>
+#include <unordered_map>
 #include <vector>
 
 #include <backends.hpp>
@@ -98,7 +99,7 @@ private:
     local_spike_store_type& previous_spikes() { return local_spikes_.other(); }
 
     // Pending events to be delivered.
-    std::vector<std::vector<event_vector>> event_lanes_;
+    std::array<std::vector<event_vector>, 2> event_lanes_;
 
     // Sampler associations handles are managed by a helper class.
     util::handle_set<sampler_association_handle> sassoc_handles_;

--- a/src/rss_cell_group.hpp
+++ b/src/rss_cell_group.hpp
@@ -34,7 +34,7 @@ public:
 
     void set_binning_policy(binning_kind policy, time_type bin_interval) override {}
 
-    void advance(epoch ep, time_type dt) override {
+    void advance(epoch ep, time_type dt, const event_lane_subrange& events) override {
         for (const auto& cell: cells_) {
             auto t = std::max(cell.start_time, time_);
             auto t_end = std::min(cell.stop_time, ep.tfinal);
@@ -47,10 +47,6 @@ public:
         time_ = ep.tfinal;
     }
 
-    void enqueue_events(epoch, util::subrange_view_type<std::vector<std::vector<postsynaptic_spike_event>>>) override {
-        std::logic_error("rss_cell cannot deliver events");
-    }
-
     const std::vector<spike>& spikes() const override {
         return spikes_;
     }
@@ -59,7 +55,7 @@ public:
         spikes_.clear();
     }
 
-    virtual void add_sampler(sampler_association_handle, cell_member_predicate, schedule, sampler_function, sampling_policy) {
+    void add_sampler(sampler_association_handle, cell_member_predicate, schedule, sampler_function, sampling_policy) override {
         std::logic_error("rss_cell does not support sampling");
     }
 

--- a/src/util/rangeutil.hpp
+++ b/src/util/rangeutil.hpp
@@ -146,11 +146,25 @@ sort(Seq& seq) {
     std::sort(std::begin(canon), std::end(canon));
 }
 
+template <typename Seq, typename Less>
+enable_if_t<!std::is_const<typename sequence_traits<Seq>::reference>::value>
+sort(Seq& seq, const Less& less) {
+    auto canon = canonical_view(seq);
+    std::sort(std::begin(canon), std::end(canon), less);
+}
+
 template <typename Seq>
 enable_if_t<!std::is_const<typename sequence_traits<Seq>::reference>::value>
 sort(const Seq& seq) {
     auto canon = canonical_view(seq);
     std::sort(std::begin(canon), std::end(canon));
+}
+
+template <typename Seq, typename Less>
+enable_if_t<!std::is_const<typename sequence_traits<Seq>::reference>::value>
+sort(const Seq& seq, const Less& less) {
+    auto canon = canonical_view(seq);
+    std::sort(std::begin(canon), std::end(canon), less);
 }
 
 // Sort in-place by projection `proj`

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -54,6 +54,7 @@ set(TEST_SOURCES
     test_math.cpp
     test_matrix.cpp
     test_mechanisms.cpp
+    test_merge_events.cpp
     test_multi_event_stream.cpp
     test_nop.cpp
     test_optional.cpp

--- a/tests/unit/test_dss_cell_group.cpp
+++ b/tests/unit/test_dss_cell_group.cpp
@@ -19,14 +19,14 @@ TEST(dss_cell, basic_usage)
     // No spikes in this time frame.
     time_type dt = 0.01; // (note that dt is ignored in dss_cell_group).
     epoch ep(0, 0.09);
-    sut.advance(ep, dt);
+    sut.advance(ep, dt, {});
 
     auto spikes = sut.spikes();
     EXPECT_EQ(0u, spikes.size());
 
     // Only one in this time frame.
     ep.advance(0.11);
-    sut.advance(ep, dt);
+    sut.advance(ep, dt, {});
     spikes = sut.spikes();
     EXPECT_EQ(1u, spikes.size());
     ASSERT_FLOAT_EQ(spike_time, spikes[0].time);
@@ -38,7 +38,7 @@ TEST(dss_cell, basic_usage)
 
     // No spike to be emitted.
     ep.advance(0.12);
-    sut.advance(ep, dt);
+    sut.advance(ep, dt, {});
     spikes = sut.spikes();
     EXPECT_EQ(0u, spikes.size());
 
@@ -47,7 +47,7 @@ TEST(dss_cell, basic_usage)
 
     // Expect to have the one spike again after reset.
     ep.advance(0.2);
-    sut.advance(ep, dt);
+    sut.advance(ep, dt, {});
     spikes = sut.spikes();
     EXPECT_EQ(1u, spikes.size());
     ASSERT_FLOAT_EQ(spike_time, spikes[0].time);

--- a/tests/unit/test_mc_cell_group.cpp
+++ b/tests/unit/test_mc_cell_group.cpp
@@ -33,7 +33,7 @@ TEST(mc_cell_group, get_kind) {
 TEST(mc_cell_group, test) {
     mc_cell_group<fvm_cell> group{{0}, cable1d_recipe(make_cell()) };
 
-    group.advance(epoch(0, 50), 0.01);
+    group.advance(epoch(0, 50), 0.01, {});
 
     // the model is expected to generate 4 spikes as a result of the
     // fixed stimulus over 50 ms

--- a/tests/unit/test_merge_events.cpp
+++ b/tests/unit/test_merge_events.cpp
@@ -6,12 +6,8 @@
 namespace arb {
     // Declare prototype of the merge_events function, because it is only
     // defined in the TU of model.cpp
-    void merge_events(
-        event_vector& events,
-        const event_vector& lc,
-        event_vector& lf,
-        time_type tfinal);
-}
+    void merge_events(time_type tfinal, const event_vector& lc, event_vector& events, event_vector& lf);
+} // namespace arb
 
 using namespace arb;
 
@@ -32,7 +28,7 @@ TEST(merge_events, empty)
     event_vector lc;
     event_vector lf;
 
-    merge_events(events, lc, lf, 0);
+    merge_events(0, lc, events, lf);
 
     EXPECT_EQ(lf.size(), 0u);
 }
@@ -64,7 +60,7 @@ TEST(merge_events, no_overlap)
         {{0, 0}, 11, 1},
     };
 
-    merge_events(events, lc, lf, 10);
+    merge_events(10, lc, events, lf);
 
     event_vector expected = {
         {{8, 0}, 10, 4},
@@ -102,7 +98,7 @@ TEST(merge_events, overlap)
         {{7, 0}, 10, 8},
     };
 
-    merge_events(events, lc, lf, 10);
+    merge_events(10, lc, events, lf);
 
     event_vector expected = {
         {{7, 0}, 10, 8}, // from events

--- a/tests/unit/test_merge_events.cpp
+++ b/tests/unit/test_merge_events.cpp
@@ -1,0 +1,119 @@
+#include "../gtest.h"
+
+#include <event_queue.hpp>
+#include <model.hpp>
+
+namespace arb {
+    // Declare prototype of the merge_events function, because it is only
+    // defined in the TU of model.cpp
+    void merge_events(
+        event_vector& events,
+        const event_vector& lc,
+        event_vector& lf,
+        time_type tfinal);
+}
+
+using namespace arb;
+
+std::ostream& operator<<(std::ostream& o, const event_vector& events) {
+    o << "{{"; for (auto e: events) o << " " << e;
+    o << "}}";
+    return o;
+}
+
+using pse = postsynaptic_spike_event;
+auto ev_bind = [] (const pse& e){ return std::tie(e.time, e.target, e.weight); };
+auto ev_less = [] (const pse& l, const pse& r){ return ev_bind(l)<ev_bind(r); };
+
+// Test the trivial case of merging empty sets
+TEST(merge_events, empty)
+{
+    event_vector events;
+    event_vector lc;
+    event_vector lf;
+
+    merge_events(events, lc, lf, 0);
+
+    EXPECT_EQ(lf.size(), 0u);
+}
+
+// Test the case where there are no events in lc that are to be delivered
+// after tfinal.
+TEST(merge_events, no_overlap)
+{
+    event_vector lc = {
+        {{0, 0}, 1, 1},
+        {{0, 0}, 2, 1},
+        {{0, 0}, 3, 3},
+    };
+    // Check that the inputs satisfy the precondition that lc is sorted.
+    EXPECT_TRUE(std::is_sorted(lc.begin(), lc.end(), ev_less));
+
+    // These events should be removed from lf by merge_events, and replaced
+    // with events to be delivered after t=10
+    event_vector lf = {
+        {{0, 0}, 1, 1},
+        {{0, 0}, 2, 1},
+        {{0, 0}, 3, 3},
+    };
+
+    event_vector events = {
+        {{0, 0}, 12, 1},
+        {{0, 0}, 11, 2},
+        {{8, 0}, 10, 4},
+        {{0, 0}, 11, 1},
+    };
+
+    merge_events(events, lc, lf, 10);
+
+    event_vector expected = {
+        {{8, 0}, 10, 4},
+        {{0, 0}, 11, 1},
+        {{0, 0}, 11, 2},
+        {{0, 0}, 12, 1},
+    };
+
+    EXPECT_TRUE(std::is_sorted(lf.begin(), lf.end(), ev_less));
+    EXPECT_EQ(expected, lf);
+}
+
+// Test case where current events (lc) contains events that must be deilvered
+// in a future epoch, i.e. events with delivery time greater than the tfinal
+// argument passed to merge_events.
+TEST(merge_events, overlap)
+{
+    event_vector lc = {
+        {{0, 0}, 1, 1},
+        {{0, 0}, 2, 1},
+        // The current epoch ends at t=10, so all events from here down are expected in lf.
+        {{8, 0}, 10, 2},
+        {{0, 0}, 11, 3},
+    };
+    EXPECT_TRUE(std::is_sorted(lc.begin(), lc.end(), ev_less));
+
+    event_vector lf;
+
+    event_vector events = {
+        // events are in reverse order: they should be sorted in the output of merge_events.
+        {{0, 0}, 12, 1},
+        {{0, 0}, 11, 2},
+        {{0, 0}, 11, 1},
+        {{8, 0}, 10, 3},
+        {{7, 0}, 10, 8},
+    };
+
+    merge_events(events, lc, lf, 10);
+
+    event_vector expected = {
+        {{7, 0}, 10, 8}, // from events
+        {{8, 0}, 10, 2}, // from lc
+        {{8, 0}, 10, 3}, // from events
+        {{0, 0}, 11, 1}, // from events
+        {{0, 0}, 11, 2}, // from events
+        {{0, 0}, 11, 3}, // from lc
+        {{0, 0}, 12, 1}, // from events
+    };
+
+    EXPECT_TRUE(std::is_sorted(lf.begin(), lf.end(), ev_less));
+    EXPECT_EQ(expected, lf);
+}

--- a/tests/unit/test_merge_events.cpp
+++ b/tests/unit/test_merge_events.cpp
@@ -6,12 +6,12 @@
 namespace arb {
     // Declare prototype of the merge_events function, because it is only
     // defined in the TU of model.cpp
-    void merge_events(time_type tfinal, const event_vector& lc, event_vector& events, event_vector& lf);
+    void merge_events(time_type tfinal, const pse_vector& lc, pse_vector& events, pse_vector& lf);
 } // namespace arb
 
 using namespace arb;
 
-std::ostream& operator<<(std::ostream& o, const event_vector& events) {
+std::ostream& operator<<(std::ostream& o, const pse_vector& events) {
     o << "{{"; for (auto e: events) o << " " << e;
     o << "}}";
     return o;
@@ -24,9 +24,9 @@ auto ev_less = [] (const pse& l, const pse& r){ return ev_bind(l)<ev_bind(r); };
 // Test the trivial case of merging empty sets
 TEST(merge_events, empty)
 {
-    event_vector events;
-    event_vector lc;
-    event_vector lf;
+    pse_vector events;
+    pse_vector lc;
+    pse_vector lf;
 
     merge_events(0, lc, events, lf);
 
@@ -37,7 +37,7 @@ TEST(merge_events, empty)
 // after tfinal.
 TEST(merge_events, no_overlap)
 {
-    event_vector lc = {
+    pse_vector lc = {
         {{0, 0}, 1, 1},
         {{0, 0}, 2, 1},
         {{0, 0}, 3, 3},
@@ -47,13 +47,13 @@ TEST(merge_events, no_overlap)
 
     // These events should be removed from lf by merge_events, and replaced
     // with events to be delivered after t=10
-    event_vector lf = {
+    pse_vector lf = {
         {{0, 0}, 1, 1},
         {{0, 0}, 2, 1},
         {{0, 0}, 3, 3},
     };
 
-    event_vector events = {
+    pse_vector events = {
         {{0, 0}, 12, 1},
         {{0, 0}, 11, 2},
         {{8, 0}, 10, 4},
@@ -62,7 +62,7 @@ TEST(merge_events, no_overlap)
 
     merge_events(10, lc, events, lf);
 
-    event_vector expected = {
+    pse_vector expected = {
         {{8, 0}, 10, 4},
         {{0, 0}, 11, 1},
         {{0, 0}, 11, 2},
@@ -78,7 +78,7 @@ TEST(merge_events, no_overlap)
 // argument passed to merge_events.
 TEST(merge_events, overlap)
 {
-    event_vector lc = {
+    pse_vector lc = {
         {{0, 0}, 1, 1},
         {{0, 0}, 2, 1},
         // The current epoch ends at t=10, so all events from here down are expected in lf.
@@ -87,9 +87,9 @@ TEST(merge_events, overlap)
     };
     EXPECT_TRUE(std::is_sorted(lc.begin(), lc.end(), ev_less));
 
-    event_vector lf;
+    pse_vector lf;
 
-    event_vector events = {
+    pse_vector events = {
         // events are in reverse order: they should be sorted in the output of merge_events.
         {{0, 0}, 12, 1},
         {{0, 0}, 11, 2},
@@ -100,7 +100,7 @@ TEST(merge_events, overlap)
 
     merge_events(10, lc, events, lf);
 
-    event_vector expected = {
+    pse_vector expected = {
         {{7, 0}, 10, 8}, // from events
         {{8, 0}, 10, 2}, // from lc
         {{8, 0}, 10, 3}, // from events

--- a/tests/unit/test_range.cpp
+++ b/tests/unit/test_range.cpp
@@ -402,6 +402,12 @@ TEST(range, assign_from) {
     }
 }
 
+struct foo {
+    int x;
+    int y;
+    friend bool operator==(const foo& l, const foo& r) {return l.x==r.x && l.y==r.y;};
+};
+
 TEST(range, sort) {
     char cstr[] = "howdy";
 
@@ -428,6 +434,16 @@ TEST(range, sort) {
 
     util::stable_sort_by(util::strict_view(mixed_range), rank);
     EXPECT_EQ(std::string("HELLOthere54321"), mixed);
+
+
+    // sort with user-provided less comparison function
+
+    std::vector<foo> X = {{0, 5}, {1, 4}, {2, 3}, {3, 2}, {4, 1}, {5, 0}};
+
+    util::sort(X, [](const foo& l, const foo& r) {return l.y<r.y;});
+    EXPECT_EQ(X, (std::vector<foo>{{5, 0}, {4, 1}, {3, 2}, {2, 3}, {1, 4}, {0, 5}}));
+    util::sort(X, [](const foo& l, const foo& r) {return l.x<r.x;});
+    EXPECT_EQ(X, (std::vector<foo>{{0, 5}, {1, 4}, {2, 3}, {3, 2}, {4, 1}, {5, 0}}));
 }
 
 TEST(range, sum_by) {

--- a/tests/unit/test_rss_cell.cpp
+++ b/tests/unit/test_rss_cell.cpp
@@ -20,13 +20,13 @@ TEST(rss_cell, basic_usage)
 
     // No spikes in this time frame.
     epoch ep(0, 0.1);
-    sut.advance(ep, dt);
+    sut.advance(ep, dt, {});
     EXPECT_EQ(0u, sut.spikes().size());
 
     // Only on in this time frame
     sut.clear_spikes();
     ep.advance(0.127);
-    sut.advance(ep, dt);
+    sut.advance(ep, dt, {});
     EXPECT_EQ(1u, sut.spikes().size());
 
     // Reset cell group state.
@@ -34,7 +34,7 @@ TEST(rss_cell, basic_usage)
 
     // Expect 12 spikes excluding the 0.5 end point.
     ep.advance(0.5);
-    sut.advance(ep, dt);
+    sut.advance(ep, dt, {});
     EXPECT_EQ(12u, sut.spikes().size());
 }
 
@@ -46,19 +46,19 @@ TEST(rss_cell, poll_time_after_end_time)
     rss_cell_group sut({0}, rss_recipe(1u, desc));
 
     // Expect 12 spikes in this time frame.
-    sut.advance(epoch(0, 0.7), dt);
+    sut.advance(epoch(0, 0.7), dt, {});
     EXPECT_EQ(12u, sut.spikes().size());
 
     // Now ask for spikes for a time slot already passed:
     // It should result in zero spikes because of the internal state!
     sut.clear_spikes();
-    sut.advance(epoch(0, 0.2), dt);
+    sut.advance(epoch(0, 0.2), dt, {});
     EXPECT_EQ(0u, sut.spikes().size());
 
     sut.reset();
 
     // Expect 12 excluding the 0.5
-    sut.advance(epoch(0, 0.5), dt);
+    sut.advance(epoch(0, 0.5), dt, {});
     EXPECT_EQ(12u, sut.spikes().size());
 }
 

--- a/tests/validation/validate_synapses.cpp
+++ b/tests/validation/validate_synapses.cpp
@@ -42,11 +42,11 @@ void run_synapse_test(
     c.add_synapse({1, 0.5}, syn_default);
 
     // injected spike events
-    std::vector<std::vector<postsynaptic_spike_event>> synthetic_events = {{
+    std::vector<postsynaptic_spike_event> synthetic_events = {
         {{0u, 0u}, 10.0, 0.04},
         {{0u, 0u}, 20.0, 0.04},
         {{0u, 0u}, 40.0, 0.04}
-    }};
+    };
 
     // exclude points of discontinuity from linf analysis
     std::vector<float> exclude = {10.f, 20.f, 40.f};
@@ -76,9 +76,7 @@ void run_synapse_test(
         auto decomp = partition_load_balance(rec, nd);
         model m(rec, decomp);
 
-        // Add events an odd epoch (1), so that they are available during integration of epoch 0.
-        // This is a bit of a hack.
-        //m.group(0).enqueue_events(epoch(1, 0.), util::subrange_view(synthetic_events, 0, 1));
+        m.inject_events(synthetic_events);
 
         runner.run(m, ncomp, sample_dt, t_end, dt, exclude);
     }

--- a/tests/validation/validate_synapses.cpp
+++ b/tests/validation/validate_synapses.cpp
@@ -78,7 +78,7 @@ void run_synapse_test(
 
         // Add events an odd epoch (1), so that they are available during integration of epoch 0.
         // This is a bit of a hack.
-        m.group(0).enqueue_events(epoch(1, 0.), util::subrange_view(synthetic_events, 0, 1));
+        //m.group(0).enqueue_events(epoch(1, 0.), util::subrange_view(synthetic_events, 0, 1));
 
         runner.run(m, ncomp, sample_dt, t_end, dt, exclude);
     }


### PR DESCRIPTION
Remove `cell_group::enqueue_events` interface:
* replace by passing a sorted list of events to the `cell_group::advance` method.
* `cell_group` is provided with events to deliver in each epoch: no longer needs to keep track of events due in future epochs. 

Add stand alone `merge_events` method:
* generates a sorted list of events to be delivered after the current epoch is finished.
* takes an unsorted set of events and the sorted set of events already in the model.
* simplifies unit testing.

Implement reproduceable ordering of events:
* order events to be delivered in ascending order of time, then target, then weight.
* fixes very infrequent collisions where two events with different weights are delivered
to the same target simultanously. On different systems the order in which events were delivered in different orders. 
* fixes #385
                                                                                                         
Fixes #378