### PR TITLE
modcc enforces derivatives only on state variables

### DIFF
--- a/modcc/expression.cpp
+++ b/modcc/expression.cpp
@@ -127,6 +127,16 @@ expression_ptr DerivativeExpression::clone() const {
     return make_expression<DerivativeExpression>(location_, spelling_);
 }
 
+void DerivativeExpression::semantic(scope_ptr scp) {
+    IdentifierExpression::semantic(scp);
+    auto v = symbol_->is_variable();
+    if (!v || !v->is_state()) {
+        error( pprintf("the variable '%' must be a state variable to be differentiated",
+                        yellow(spelling_), location_));
+        return;
+    }
+}
+
 /*******************************************************************************
   NumberExpression
 ********************************************************************************/

--- a/modcc/expression.hpp
+++ b/modcc/expression.hpp
@@ -315,6 +315,8 @@ public:
 
     expression_ptr clone() const override;
 
+    void semantic(scope_ptr scp) override;
+
     DerivativeExpression* is_derivative() override { return this; }
 
     ~DerivativeExpression() {}


### PR DESCRIPTION
Specialise the semantic analysis of `DerivativeExpression` to enforce that derivatives are only applied to state variables.

Derivatives only appear on the left hand side of expressions that describe the time evolution of state variables, so this is entirely reasonable.
Without this check the modcc compiler was producing undefined behavior when a user eroniously took the derivative of a non-state variable.