### PR TITLE
Fix GPU event delivery bugs

### DIFF
--- a/src/model.cpp
+++ b/src/model.cpp
@@ -115,7 +115,7 @@ time_type model::run(time_type tfinal, time_type dt) {
         PL();
 
         PE("enqueue");
-        threading::parallel_for::apply(0, num_groups(),
+        threading::parallel_for::apply(0, communicator_.num_local_cells(),
             [&](cell_size_type i) {
                 const auto epid = epoch_.id;
                 merge_events(

--- a/tests/unit/test_mc_cell_group.cu
+++ b/tests/unit/test_mc_cell_group.cu
@@ -26,7 +26,7 @@ TEST(mc_cell_group, test)
 {
     mc_cell_group<fvm_cell> group({0u}, cable1d_recipe(make_cell()));
 
-    group.advance(epoch(0, 50), 0.01);
+    group.advance(epoch(0, 50), 0.01, {});
 
     // the model is expected to generate 4 spikes as a result of the
     // fixed stimulus over 50 ms


### PR DESCRIPTION
Fix two issues:

* Not all event queues were being delivered for groups with more than one cell, which affected the GPU version of the miniapp.
* A GPU unit test was updated to use the new `cell_group::advance()` interface.