### PR TITLE
Fix indirection in ion concentration write.

### DIFF
--- a/modcc/cprinter.cpp
+++ b/modcc/cprinter.cpp
@@ -319,9 +319,8 @@ std::string CPrinter::emit_source() {
             text_.add_line("for (size_type i_ = 0; i_ < n_; ++i_) {");
             text_.increase_indentation();
             text_.add_line("// 1/10 magic number due to unit normalisation");
-            text_.add_line(src+"_out_["+istore+"index[i_]] += value_type(0.1)*weights_[i_]*"+src+"[i_];");
+            text_.add_line(src+"_out_[i_] += value_type(0.1)*weights_[i_]*"+src+"[i_];");
             text_.decrease_indentation(); text_.add_line("}");
-            
         }
         text_.decrease_indentation(); text_.add_line("}");
     }

--- a/tests/unit/test_fvm_multi.cpp
+++ b/tests/unit/test_fvm_multi.cpp
@@ -856,10 +856,6 @@ TEST(fvm_multi, ion_weights) {
     double con_int = 80;
     double con_ext = 120;
 
-    //std::vector<std::vector<fvm_value_type>> expected_wght = {
-    //    {1./3}, {1./3, 1./2, 0.}, {1./4, 0., 0.}, {0., 0., 0., 0.},
-    //};
-
     auto construct_cell = [](cell& c) {
         c.add_soma(5);
 


### PR DESCRIPTION
* Remove second indirection in ion write assignment.
* Extend ion write unit test to cover non-contiguous ion CV cases and verify correct ion concentration averaging.

Fixes #424.