### PR TITLE
Make cell type copyable by default

### DIFF
--- a/example/miniapp/miniapp_recipes.cpp
+++ b/example/miniapp/miniapp_recipes.cpp
@@ -86,7 +86,7 @@ public:
         return ncell_ + 1;  // We automatically add a fake cell to each recipe!
     }
 
-    util::any get_cell_description(cell_gid_type i) const override {
+    util::unique_any get_cell_description(cell_gid_type i) const override {
         // The last 'cell' is a spike source cell. Either a regular spiking
         // or a spikes from file.
         if (i == ncell_) {
@@ -95,7 +95,7 @@ public:
                 return util::any(dss_cell_description(spike_times));
             }
 
-            return util::any(rss_cell{0.0, 0.1, 0.1});
+            return util::unique_any(rss_cell{0.0, 0.1, 0.1});
         }
 
         auto gen = std::mt19937(i); // TODO: replace this with hashing generator...
@@ -110,7 +110,7 @@ public:
         EXPECTS(cell.synapses().size()==num_targets(i));
         EXPECTS(cell.detectors().size()==num_sources(i));
 
-        return util::any(std::move(cell));
+        return util::unique_any(std::move(cell));
     }
 
     probe_info get_probe(cell_member_type probe_id) const override {
@@ -174,10 +174,6 @@ public:
             cell_size_type np = pdist_.all_segments? get_morphology(i).components(): 1;
             return np*(pdist_.membrane_voltage+pdist_.membrane_current);
         }
-    }
-
-    std::vector<event_generator_ptr> event_generators(cell_gid_type) const override {
-        return {};
     }
 
 protected:

--- a/example/miniapp/miniapp_recipes.cpp
+++ b/example/miniapp/miniapp_recipes.cpp
@@ -92,7 +92,7 @@ public:
         if (i == ncell_) {
             if (param_.input_spike_path) {
                 auto spike_times = io::get_parsed_spike_times_from_path(param_.input_spike_path.value());
-                return util::any(dss_cell_description(spike_times));
+                return util::unique_any(dss_cell_description(spike_times));
             }
 
             return util::unique_any(rss_cell{0.0, 0.1, 0.1});

--- a/example/miniapp/miniapp_recipes.cpp
+++ b/example/miniapp/miniapp_recipes.cpp
@@ -86,16 +86,16 @@ public:
         return ncell_ + 1;  // We automatically add a fake cell to each recipe!
     }
 
-    util::unique_any get_cell_description(cell_gid_type i) const override {
+    util::any get_cell_description(cell_gid_type i) const override {
         // The last 'cell' is a spike source cell. Either a regular spiking
         // or a spikes from file.
         if (i == ncell_) {
             if (param_.input_spike_path) {
                 auto spike_times = io::get_parsed_spike_times_from_path(param_.input_spike_path.value());
-                return util::unique_any(dss_cell_description(spike_times));
+                return util::any(dss_cell_description(spike_times));
             }
 
-            return util::unique_any(rss_cell{0.0, 0.1, 0.1});
+            return util::any(rss_cell{0.0, 0.1, 0.1});
         }
 
         auto gen = std::mt19937(i); // TODO: replace this with hashing generator...
@@ -110,7 +110,7 @@ public:
         EXPECTS(cell.synapses().size()==num_targets(i));
         EXPECTS(cell.detectors().size()==num_sources(i));
 
-        return util::unique_any(std::move(cell));
+        return util::any(std::move(cell));
     }
 
     probe_info get_probe(cell_member_type probe_id) const override {

--- a/src/cell.hpp
+++ b/src/cell.hpp
@@ -54,10 +54,6 @@ struct cell_global_properties {
     std::map<std::string, specialized_mechanism> special_mechs;
 };
 
-// used in constructor below
-struct clone_cell_t {};
-constexpr clone_cell_t clone_cell{};
-
 /// high-level abstract representation of a cell and its segments
 class cell {
 public:
@@ -81,22 +77,25 @@ public:
         double threshold;
     };
 
-    // constructor
+    /// Default constructor
     cell();
 
-    // Sometimes we really do want a copy (pending big morphology refactor).
-    cell(clone_cell_t, const cell& other):
+    /// Copy constructor
+    cell(const cell& other):
         parents_(other.parents_),
         stimuli_(other.stimuli_),
         synapses_(other.synapses_),
         spike_detectors_(other.spike_detectors_)
-     {
-         // unique_ptr's cannot be copy constructed, do a manual assignment
-         segments_.reserve(other.segments_.size());
-         for (const auto& s: other.segments_) {
-             segments_.push_back(s->clone());
-         }
-     }
+    {
+        // unique_ptr's cannot be copy constructed, do a manual assignment
+        segments_.reserve(other.segments_.size());
+        for (const auto& s: other.segments_) {
+            segments_.push_back(s->clone());
+        }
+    }
+
+    /// Move constructor
+    cell(cell&& other) = default;
 
     /// Return the kind of cell, used for grouping into cell_groups
     cell_kind get_cell_kind() const  {

--- a/src/common_types.hpp
+++ b/src/common_types.hpp
@@ -76,6 +76,7 @@ enum cell_kind {
 } // namespace arb
 
 std::ostream& operator<<(std::ostream& O, arb::cell_member_type m);
+std::ostream& operator<<(std::ostream& O, arb::cell_kind k);
 
 namespace std {
     template <> struct hash<arb::cell_member_type> {

--- a/src/common_types_io.cpp
+++ b/src/common_types_io.cpp
@@ -6,3 +6,16 @@ std::ostream& operator<<(std::ostream& O, arb::cell_member_type m) {
     return O << m.gid << ':' << m.index;
 }
 
+std::ostream& operator<<(std::ostream& o, arb::cell_kind k) {
+    o << "cell_kind::";
+    switch (k) {
+    case arb::cell_kind::regular_spike_source:
+        return o << "regular_spike_source";
+    case arb::cell_kind::cable1d_neuron:
+        return o << "cable1d_neuron";
+    case arb::cell_kind::data_spike_source:
+        return o << "data_spike_source";
+    }
+    return o;
+}
+

--- a/src/fvm_multicell.hpp
+++ b/src/fvm_multicell.hpp
@@ -638,7 +638,7 @@ void fvm_multicell<Backend>::initialize(
     std::vector<cell> cells;
     cells.reserve(gids.size());
     for (auto gid: gids) {
-        cells.push_back(any_cast<cell>(rec.get_cell_description(gid)));
+        cells.push_back(std::move(any_cast<cell>(rec.get_cell_description(gid))));
     }
 
     auto cell_num_compartments =

--- a/src/recipe.hpp
+++ b/src/recipe.hpp
@@ -64,10 +64,16 @@ public:
     virtual cell_size_type num_targets(cell_gid_type) const { return 0; }
     virtual cell_size_type num_probes(cell_gid_type)  const { return 0; }
 
-    virtual std::vector<event_generator_ptr> event_generators(cell_gid_type) const { return {}; }
+    virtual std::vector<event_generator_ptr> event_generators(cell_gid_type) const {
+        return {};
+    }
+    virtual std::vector<cell_connection> connections_on(cell_gid_type) const {
+        return {};
+    }
+    virtual probe_info get_probe(cell_member_type) const {
+        throw std::logic_error("no probes");
+    }
 
-    virtual std::vector<cell_connection> connections_on(cell_gid_type) const { return {}; }
-    virtual probe_info get_probe(cell_member_type probe_id) const { return probe_info(); }
 
     // Global property type will be specific to given cell kind.
     virtual util::any get_global_properties(cell_kind) const { return util::any{}; };

--- a/src/recipe.hpp
+++ b/src/recipe.hpp
@@ -57,7 +57,7 @@ public:
     virtual cell_size_type num_cells() const = 0;
 
     // Cell description type will be specific to cell kind of cell with given gid.
-    virtual util::unique_any get_cell_description(cell_gid_type gid) const = 0;
+    virtual util::any get_cell_description(cell_gid_type gid) const = 0;
     virtual cell_kind get_cell_kind(cell_gid_type) const = 0;
 
     virtual cell_size_type num_sources(cell_gid_type) const = 0;

--- a/src/recipe.hpp
+++ b/src/recipe.hpp
@@ -57,17 +57,17 @@ public:
     virtual cell_size_type num_cells() const = 0;
 
     // Cell description type will be specific to cell kind of cell with given gid.
-    virtual util::any get_cell_description(cell_gid_type gid) const = 0;
+    virtual util::unique_any get_cell_description(cell_gid_type gid) const = 0;
     virtual cell_kind get_cell_kind(cell_gid_type) const = 0;
 
-    virtual cell_size_type num_sources(cell_gid_type) const = 0;
-    virtual cell_size_type num_targets(cell_gid_type) const = 0;
-    virtual cell_size_type num_probes(cell_gid_type) const = 0;
+    virtual cell_size_type num_sources(cell_gid_type) const { return 0; }
+    virtual cell_size_type num_targets(cell_gid_type) const { return 0; }
+    virtual cell_size_type num_probes(cell_gid_type)  const { return 0; }
 
-    virtual std::vector<event_generator_ptr> event_generators(cell_gid_type) const = 0;
+    virtual std::vector<event_generator_ptr> event_generators(cell_gid_type) const { return {}; }
 
-    virtual std::vector<cell_connection> connections_on(cell_gid_type) const = 0;
-    virtual probe_info get_probe(cell_member_type probe_id) const = 0;
+    virtual std::vector<cell_connection> connections_on(cell_gid_type) const { return {}; }
+    virtual probe_info get_probe(cell_member_type probe_id) const { return probe_info(); }
 
     // Global property type will be specific to given cell kind.
     virtual util::any get_global_properties(cell_kind) const { return util::any{}; };

--- a/tests/global_communication/test_communicator.cpp
+++ b/tests/global_communication/test_communicator.cpp
@@ -213,10 +213,6 @@ namespace {
                         1.0f)};     // delay
         }
 
-        probe_info get_probe(cell_member_type) const override {
-            throw std::logic_error("no probes");
-        }
-
     private:
         cell_size_type size_;
         cell_size_type ranks_;
@@ -280,10 +276,6 @@ namespace {
                 cons.push_back(con);
             }
             return cons;
-        }
-
-        probe_info get_probe(cell_member_type) const override {
-            throw std::logic_error("no probes");
         }
 
     private:

--- a/tests/global_communication/test_communicator.cpp
+++ b/tests/global_communication/test_communicator.cpp
@@ -189,7 +189,7 @@ namespace {
             return size_;
         }
 
-        util::unique_any get_cell_description(cell_gid_type) const override {
+        util::any get_cell_description(cell_gid_type) const override {
             return {};
         }
 
@@ -261,7 +261,7 @@ namespace {
             return size_;
         }
 
-        util::unique_any get_cell_description(cell_gid_type) const override {
+        util::any get_cell_description(cell_gid_type) const override {
             return {};
         }
         cell_kind get_cell_kind(cell_gid_type gid) const override {

--- a/tests/global_communication/test_communicator.cpp
+++ b/tests/global_communication/test_communicator.cpp
@@ -189,7 +189,7 @@ namespace {
             return size_;
         }
 
-        util::any get_cell_description(cell_gid_type) const override {
+        util::unique_any get_cell_description(cell_gid_type) const override {
             return {};
         }
 
@@ -211,10 +211,6 @@ namespace {
                         src, dst,   // end points
                         float(gid), // weight
                         1.0f)};     // delay
-        }
-
-        std::vector<event_generator_ptr> event_generators(cell_gid_type) const override {
-            return {};
         }
 
         probe_info get_probe(cell_member_type) const override {
@@ -261,7 +257,7 @@ namespace {
             return size_;
         }
 
-        util::any get_cell_description(cell_gid_type) const override {
+        util::unique_any get_cell_description(cell_gid_type) const override {
             return {};
         }
         cell_kind get_cell_kind(cell_gid_type gid) const override {
@@ -284,10 +280,6 @@ namespace {
                 cons.push_back(con);
             }
             return cons;
-        }
-
-        std::vector<event_generator_ptr> event_generators(cell_gid_type) const override {
-            return {};
         }
 
         probe_info get_probe(cell_member_type) const override {

--- a/tests/global_communication/test_domain_decomposition.cpp
+++ b/tests/global_communication/test_domain_decomposition.cpp
@@ -58,9 +58,6 @@ namespace {
             return {};
         }
 
-        probe_info get_probe(cell_member_type) const override {
-            throw std::logic_error("no probes");
-        }
 
     private:
         cell_size_type size_;

--- a/tests/global_communication/test_domain_decomposition.cpp
+++ b/tests/global_communication/test_domain_decomposition.cpp
@@ -36,7 +36,7 @@ namespace {
             return size_;
         }
 
-        util::any get_cell_description(cell_gid_type) const override {
+        util::unique_any get_cell_description(cell_gid_type) const override {
             return {};
         }
 

--- a/tests/global_communication/test_domain_decomposition.cpp
+++ b/tests/global_communication/test_domain_decomposition.cpp
@@ -36,7 +36,7 @@ namespace {
             return size_;
         }
 
-        util::unique_any get_cell_description(cell_gid_type) const override {
+        util::any get_cell_description(cell_gid_type) const override {
             return {};
         }
 

--- a/tests/simple_recipes.hpp
+++ b/tests/simple_recipes.hpp
@@ -20,14 +20,6 @@ public:
         return probes_.count(i)? probes_.at(i).size(): 0;
     }
 
-    std::vector<event_generator_ptr> event_generators(cell_gid_type) const override {
-        return {};
-    }
-
-    std::vector<cell_connection> connections_on(cell_gid_type) const override {
-        return {};
-    }
-
     virtual probe_info get_probe(cell_member_type probe_id) const override {
         return probes_.at(probe_id.gid).at(probe_id.index);
     }
@@ -76,11 +68,8 @@ public:
     cell_size_type num_cells() const override { return n_; }
     cell_kind get_cell_kind(cell_gid_type) const override { return Kind; }
 
-    cell_size_type num_sources(cell_gid_type) const override { return 0; }
-    cell_size_type num_targets(cell_gid_type) const override { return 0; }
-
-    util::any get_cell_description(cell_gid_type) const override {
-        return util::make_any<Description>(desc_);
+    util::unique_any get_cell_description(cell_gid_type) const override {
+        return util::make_unique_any<Description>(desc_);
     }
 
 protected:
@@ -118,8 +107,8 @@ public:
         return cells_.at(i).synapses().size();
     }
 
-    util::any get_cell_description(cell_gid_type i) const override {
-        return util::make_any<cell>(cells_[i]);
+    util::unique_any get_cell_description(cell_gid_type i) const override {
+        return util::make_unique_any<cell>(cells_[i]);
     }
 
 protected:

--- a/tests/simple_recipes.hpp
+++ b/tests/simple_recipes.hpp
@@ -79,8 +79,8 @@ public:
     cell_size_type num_sources(cell_gid_type) const override { return 0; }
     cell_size_type num_targets(cell_gid_type) const override { return 0; }
 
-    util::unique_any get_cell_description(cell_gid_type) const override {
-        return util::make_unique_any<Description>(desc_);
+    util::any get_cell_description(cell_gid_type) const override {
+        return util::make_any<Description>(desc_);
     }
 
 protected:
@@ -98,13 +98,13 @@ public:
     template <typename Seq>
     explicit cable1d_recipe(const Seq& cells) {
         for (const auto& c: cells) {
-            cells_.emplace_back(clone_cell, c);
+            cells_.emplace_back(c);
         }
     }
 
     explicit cable1d_recipe(const cell& c) {
         cells_.reserve(1);
-        cells_.emplace_back(clone_cell, c);
+        cells_.emplace_back(c);
     }
 
     cell_size_type num_cells() const override { return cells_.size(); }
@@ -118,8 +118,8 @@ public:
         return cells_.at(i).synapses().size();
     }
 
-    util::unique_any get_cell_description(cell_gid_type i) const override {
-        return util::make_unique_any<cell>(clone_cell, cells_[i]);
+    util::any get_cell_description(cell_gid_type i) const override {
+        return util::make_any<cell>(cells_[i]);
     }
 
 protected:

--- a/tests/unit/test_cell.cpp
+++ b/tests/unit/test_cell.cpp
@@ -224,7 +224,7 @@ TEST(cell, clone)
 
     // make clone
 
-    cell d(clone_cell, c);
+    cell d(c);
 
     // check equality
 

--- a/tests/unit/test_domain_decomposition.cpp
+++ b/tests/unit/test_domain_decomposition.cpp
@@ -38,10 +38,6 @@ namespace {
                 cell_kind::cable1d_neuron;
         }
 
-        probe_info get_probe(cell_member_type) const override {
-            throw std::logic_error("no probes");
-        }
-
     private:
         cell_size_type size_;
     };

--- a/tests/unit/test_domain_decomposition.cpp
+++ b/tests/unit/test_domain_decomposition.cpp
@@ -28,7 +28,7 @@ namespace {
             return size_;
         }
 
-        util::unique_any get_cell_description(cell_gid_type) const override {
+        util::any get_cell_description(cell_gid_type) const override {
             return {};
         }
 

--- a/tests/unit/test_domain_decomposition.cpp
+++ b/tests/unit/test_domain_decomposition.cpp
@@ -28,7 +28,7 @@ namespace {
             return size_;
         }
 
-        util::any get_cell_description(cell_gid_type) const override {
+        util::unique_any get_cell_description(cell_gid_type) const override {
             return {};
         }
 
@@ -36,18 +36,6 @@ namespace {
             return gid%2?
                 cell_kind::regular_spike_source:
                 cell_kind::cable1d_neuron;
-        }
-
-        cell_size_type num_sources(cell_gid_type) const override { return 0; }
-        cell_size_type num_targets(cell_gid_type) const override { return 0; }
-        cell_size_type num_probes(cell_gid_type) const override { return 0; }
-
-        std::vector<cell_connection> connections_on(cell_gid_type) const override {
-            return {};
-        }
-
-        std::vector<event_generator_ptr> event_generators(cell_gid_type) const override {
-            return {};
         }
 
         probe_info get_probe(cell_member_type) const override {

--- a/tests/validation/validate_ball_and_stick.cpp
+++ b/tests/validation/validate_ball_and_stick.cpp
@@ -2,7 +2,6 @@
 
 #include <cell.hpp>
 #include <common_types.hpp>
-#include <fvm_multicell.hpp>
 #include <load_balance.hpp>
 #include <hardware/node_info.hpp>
 #include <hardware/gpu.hpp>

--- a/tests/validation/validate_compartment_policy.cpp
+++ b/tests/validation/validate_compartment_policy.cpp
@@ -5,7 +5,6 @@
 
 #include <common_types.hpp>
 #include <cell.hpp>
-#include <fvm_multicell.hpp>
 #include <model.hpp>
 #include <recipe.hpp>
 #include <simple_sampler.hpp>

--- a/tests/validation/validate_kinetic.cpp
+++ b/tests/validation/validate_kinetic.cpp
@@ -4,7 +4,6 @@
 
 #include <common_types.hpp>
 #include <cell.hpp>
-#include <fvm_multicell.hpp>
 #include <hardware/node_info.hpp>
 #include <hardware/gpu.hpp>
 #include <load_balance.hpp>

--- a/tests/validation/validate_soma.cpp
+++ b/tests/validation/validate_soma.cpp
@@ -2,7 +2,6 @@
 
 #include <common_types.hpp>
 #include <cell.hpp>
-#include <fvm_multicell.hpp>
 #include <hardware/gpu.hpp>
 #include <hardware/node_info.hpp>
 #include <load_balance.hpp>

--- a/tests/validation/validate_synapses.cpp
+++ b/tests/validation/validate_synapses.cpp
@@ -1,6 +1,5 @@
 #include <cell.hpp>
 #include <cell_group.hpp>
-#include <fvm_multicell.hpp>
 #include <hardware/node_info.hpp>
 #include <hardware/gpu.hpp>
 #include <json/json.hpp>


### PR DESCRIPTION
This PR addresses two fixes:
1. Implement copy constructor for `cell` type
2. Add some sane defaults for `recipe` calls.

### Copying cells

Until now copying of cells required a constructor that took a special clone tag, to force users to explicitly opt-in to copying cells, which may be expensive to copy. The problem with this approach is that interfaces that require copyable types, like `util::any`, don't work with cells. 

This PR removes this restriction, with the understanding that
1. In the future we will be refactoring the cell types to be more amenable to copying cheaply
2. Copying cells has not been a performance problem in the wild: let's cross that bridge when we get to it.

### Recipe defaults

`arb::recipe` is an abstract base class, which required that all of the recipe interface be implemented in classes that inherit from `arb::recipe`. This update adds default implementations for some of the `recipe` interface, to make writing recipes simpler.

The methods with default implementations are:
* `recipe::num_sources(gid)` returns 0                                                                                                                                                                              
* `recipe::num_targets(gid)` returns 0
* `recipe::num_probes(gid)` returns 0
* `recipe::event_generators(gid)` returns an empty list (no generators)
* `recipe::connections_on(gid)` returns empty list (no connections)
* `recipe::get_probe(probe_id)`: throws runtime exception
