### PR TITLE
Value semantics for event_generators

### DIFF
--- a/example/brunel/brunel_miniapp.cpp
+++ b/example/brunel/brunel_miniapp.cpp
@@ -120,8 +120,8 @@ public:
         return cell;
     }
 
-    std::vector<event_generator_ptr> event_generators(cell_gid_type gid) const override {
-        std::vector<arb::event_generator_ptr> gens;
+    std::vector<event_generator> event_generators(cell_gid_type gid) const override {
+        std::vector<arb::event_generator> gens;
 
         std::mt19937_64 G;
         G.seed(gid + seed_);
@@ -131,12 +131,7 @@ public:
         time_type t0 = 0;
         cell_member_type target{gid, 0};
 
-        gens.push_back(arb::make_event_generator<pgen>(
-                        target,
-                        weight_ext_,
-                        G,
-                        t0,
-                        lambda_));
+        gens.emplace_back(pgen(target, weight_ext_, G, t0, lambda_));
         return gens;
     }
 

--- a/example/generators/event_gen.cpp
+++ b/example/generators/event_gen.cpp
@@ -72,7 +72,7 @@ public:
     }
 
     // Return two generators attached to the one cell.
-    std::vector<arb::event_generator_ptr> event_generators(cell_gid_type gid) const override {
+    std::vector<arb::event_generator> event_generators(cell_gid_type gid) const override {
         EXPECTS(gid==0); // There is only one cell in the model
 
         using RNG = std::mt19937_64;
@@ -88,21 +88,19 @@ public:
         double w_i = -0.005;
 
         // Make two event generators.
-        std::vector<arb::event_generator_ptr> gens;
+        std::vector<arb::event_generator> gens;
 
         // Add excitatory generator
         gens.push_back(
-            arb::make_event_generator<pgen>(
-                cell_member_type{0,0}, // Target synapse (gid, local_id).
-                w_e,                   // Weight of events to deliver
-                RNG(29562872),         // Random number generator to use
-                t0,                    // Events start being delivered from this time
-                lambda_e));            // Expected frequency (events per ms)
+            pgen(cell_member_type{0,0}, // Target synapse (gid, local_id).
+                 w_e,                   // Weight of events to deliver
+                 RNG(29562872),         // Random number generator to use
+                 t0,                    // Events start being delivered from this time
+                 lambda_e));            // Expected frequency (events per ms)
 
         // Add inhibitory generator
-        gens.push_back(
-            arb::make_event_generator<pgen>(
-                cell_member_type{0,0}, w_i, RNG(86543891), t0, lambda_i));
+        gens.emplace_back(
+            pgen(cell_member_type{0,0}, w_i, RNG(86543891), t0, lambda_i));
 
         return gens;
     }

--- a/example/generators/readme.md
+++ b/example/generators/readme.md
@@ -87,7 +87,7 @@ To add the event generators to the synapse, we implement the `recipe::event_gene
 The implementation of this with hard-coded frequencies and weights is:
 
 ```C++
-    std::vector<arb::event_generator_ptr> event_generators(cell_gid_type gid) const override {
+    std::vector<arb::event_generator> event_generators(cell_gid_type gid) const override {
         // The type of random number generator to use.
         using RNG = std::mt19937_64;
 
@@ -104,47 +104,33 @@ The implementation of this with hard-coded frequencies and weights is:
         double w_i = -0.005;
 
         // Make two event generators.
-        std::vector<arb::event_generator_ptr> gens;
+        std::vector<arb::event_generator> gens;
 
         // Add excitatory generator
-        gens.push_back(
-            arb::make_event_generator<pgen>(
-                cell_member_type{0,0}, // Target synapse (gid, local_id).
-                w_e,                   // Weight of events to deliver
-                RNG(29562872),         // Random number generator to use
-                t0,                    // Events start being delivered from this time
-                lambda_e));            // Expected frequency (events per ms)
+        gens.emplace_back(
+            pgen(cell_member_type{0,0}, // Target synapse (gid, local_id).
+                 w_e,                   // Weight of events to deliver
+                 RNG(29562872),         // Random number generator to use
+                 t0,                    // Events start being delivered from this time
+                 lambda_e));            // Expected frequency (events per ms)
 
         // Add inhibitory generator
-        gens.push_back(
-            arb::make_event_generator<pgen>(
-                cell_member_type{0,0}, w_i, RNG(86543891), t0, lambda_i));
+        gens.emplace_back(
+            pgen(cell_member_type{0,0}, w_i, RNG(86543891), t0, lambda_i));
 
         return gens;
     }
 ```
 
-The `recipe::event_generators(gid)` method returns a vector of `event_generator_ptr` that are attached to the cell with `gid`.
-
-The `event_generator_ptr` is an alias for a `unique_ptr` wrapped around an `event_generator`.
-
-```C++
-using event_generator_ptr = std::unique_ptr<event_generator>;
-```
+The `recipe::event_generators(gid)` method returns a vector of `event_generator`s that are attached to the cell with `gid`.
 
 In the implementation, an empty vector is created, and the generators are created and `push_back`ed into the vector one after the other.
 
-The helper function `make_event_generator` is used to simplify the process of creating an event generator and wrapping it in a `unique_ptr`.
-It has the same semantics as [http://en.cppreference.com/w/cpp/memory/unique_ptr/make_unique](`std::make_unique`):
-
-* It takes as a template parameter the specialized type of `event_generator`, in this case `pgen`.
-* Then it takes as arguments the arguments to pass to the constructor of `pgen`.
-
-Of the arguments passed to the Poisson event generators, the random number generator state require further explanation.
+Of the arguments used to construct the Poisson event generator `pgen`, the random number generator state require further explanation.
 Each Poisson generator has its own private random number generator state.
 The initial random number state is provided on construction.
-For a real world model, the state should have a seed that is some reproducable hash of `gid` and the generator id, to ensure reproducable random streams.
-For this simple example, we use hard coded seeds to initialize the random number state.
+For a real world model, the state should have a seed that is a hash of `gid` and the generator id, to ensure reproducable random streams.
+For this simple example, we use hard-coded seeds to initialize the random number state.
 
 ### Sampling Voltages
 

--- a/src/event_generator.hpp
+++ b/src/event_generator.hpp
@@ -11,38 +11,122 @@
 
 namespace arb {
 
+inline
+postsynaptic_spike_event terminal_pse() {
+    return postsynaptic_spike_event{cell_member_type{0,0}, max_time, 0};
+}
+
 // An event_generator generates a sequence of events to be delivered to a cell.
 // The sequence of events is always in ascending order, i.e. each event will be
 // greater than the event that proceded it, where events are ordered by:
 //  - delivery time;
 //  - then target id for events with the same delivery time;
 //  - then weight for events with the same delivery time and target.
-struct event_generator {
-    // Return the next event in the stream.
-    // Returns the same event if called multiple times without calling pop().
-    virtual postsynaptic_spike_event next() = 0;
+class event_generator {
+public:
+    //
+    // copy, move and constructor interface
+    //
+
+    event_generator(): event_generator(dummy_generator()) {}
+
+    template <typename Impl>
+    event_generator(Impl&& impl):
+        impl_(new wrap<Impl>(std::forward<Impl>(impl)))
+    {}
+
+    event_generator(event_generator&& other) = default;
+    event_generator& operator=(event_generator&& other) = default;
+
+    event_generator(const event_generator& other):
+        impl_(other.impl_->clone())
+    {}
+
+    event_generator& operator=(const event_generator& other) {
+        impl_ = other.impl_->clone();
+        return *this;
+    }
+
+    //
+    // event generator interface
+    //
+
+    // Get the current event in the stream.
+    // Does not modify the state of the stream, i.e. multiple calls to
+    // next() will return the same event in the absence of calls to pop(),
+    // advance() or reset().
+    postsynaptic_spike_event next() {
+        return impl_->next();
+    }
 
     // Move the generator to the next event in the stream.
-    virtual void pop() = 0;
+    void pop() {
+        impl_->pop();
+    }
 
     // Reset the generator to the same state that it had on construction.
-    virtual void reset() = 0;
+    void reset() {
+        impl_->reset();
+    }
 
     // Update state of the generator such that the event returned by next() is
     // the first event with delivery time >= t.
-    virtual void advance(time_type t) = 0;
+    void advance(time_type t) {
+        return impl_->advance(t);
+    }
 
-    virtual ~event_generator() {};
+private:
+    struct interface {
+        virtual postsynaptic_spike_event next() = 0;
+        virtual void pop() = 0;
+        virtual void advance(time_type t) = 0;
+        virtual void reset() = 0;
+        virtual std::unique_ptr<interface> clone() = 0;
+        virtual ~interface() {}
+    };
+
+    std::unique_ptr<interface> impl_;
+
+    template <typename Impl>
+    struct wrap: interface {
+        explicit wrap(const Impl& impl): wrapped(impl) {}
+        explicit wrap(Impl&& impl): wrapped(std::move(impl)) {}
+
+        postsynaptic_spike_event next() override {
+            return wrapped.next();
+        }
+
+        void pop() override {
+            return wrapped.pop();
+        }
+
+        void advance(time_type t) override {
+            return wrapped.advance(t);
+        }
+
+        void reset() override {
+            wrapped.reset();
+        }
+
+        std::unique_ptr<interface> clone() override {
+            return std::unique_ptr<interface>(new wrap<Impl>(wrapped));
+        }
+
+        Impl wrapped;
+    };
+
+    struct dummy_generator {
+        postsynaptic_spike_event next() { return terminal_pse(); }
+        void pop() {}
+        void reset() {}
+        void advance(time_type t) {};
+    };
+
 };
-
-inline
-postsynaptic_spike_event terminal_pse() {
-    return postsynaptic_spike_event{cell_member_type{0,0}, max_time, 0};
-}
 
 // Generator that feeds events that are specified with a vector.
 // Makes a copy of the input sequence of events.
-struct vector_backed_generator: public event_generator {
+struct vector_backed_generator {
     using pse = postsynaptic_spike_event;
     vector_backed_generator(pse_vector events):
         events_(std::move(events)),
@@ -53,21 +137,21 @@ struct vector_backed_generator: public event_generator {
         }
     }
 
-    postsynaptic_spike_event next() override {
+    postsynaptic_spike_event next() {
         return it_==events_.end()? terminal_pse(): *it_;
     }
 
-    void pop() override {
+    void pop() {
         if (it_!=events_.end()) {
             ++it_;
         }
     }
 
-    void reset() override {
+    void reset() {
         it_ = events_.begin();
     }
 
-    void advance(time_type t) override {
+    void advance(time_type t) {
         it_ = std::lower_bound(events_.begin(), events_.end(), t, event_time_less());
     }
 
@@ -81,7 +165,7 @@ private:
 // Care must be taken to avoid lifetime issues, to ensure that the generator
 // does not outlive the sequence.
 template <typename Seq>
-struct seq_generator: public event_generator {
+struct seq_generator {
     using pse = postsynaptic_spike_event;
     seq_generator(Seq& events):
         events_(events),
@@ -90,21 +174,21 @@ struct seq_generator: public event_generator {
         EXPECTS(std::is_sorted(events_.begin(), events_.end()));
     }
 
-    postsynaptic_spike_event next() override {
+    postsynaptic_spike_event next() {
         return it_==events_.end()? terminal_pse(): *it_;
     }
 
-    void pop() override {
+    void pop() {
         if (it_!=events_.end()) {
             ++it_;
         }
     }
 
-    void reset() override {
+    void reset() {
         it_ = events_.begin();
     }
 
-    void advance(time_type t) override {
+    void advance(time_type t) {
         it_ = std::lower_bound(events_.begin(), events_.end(), t, event_time_less());
     }
 
@@ -117,7 +201,7 @@ private:
 // Generates a set of regularly spaced events:
 //  * with delivery times t=t_start+n*dt, ∀ t ∈ [t_start, t_stop)
 //  * with a set target and weight
-struct regular_generator: public event_generator {
+struct regular_generator {
     using pse = postsynaptic_spike_event;
 
     regular_generator(cell_member_type target,
@@ -133,18 +217,18 @@ struct regular_generator: public event_generator {
         t_stop_(tstop)
     {}
 
-    postsynaptic_spike_event next() override {
+    postsynaptic_spike_event next() {
         const auto t = time();
         return t<t_stop_?
             postsynaptic_spike_event{target_, t, weight_}:
             terminal_pse();
     }
 
-    void pop() override {
+    void pop() {
         ++step_;
     }
 
-    void advance(time_type t0) override {
+    void advance(time_type t0) {
         t0 = std::max(t0, t_start_);
         step_ = (t0-t_start_)/dt_;
 
@@ -159,7 +243,7 @@ struct regular_generator: public event_generator {
         }
     }
 
-    void reset() override {
+    void reset() {
         step_ = 0;
     }
 
@@ -179,7 +263,7 @@ private:
 // Generates a stream of events at times described by a Poisson point process
 // with rate_per_ms spikes per ms.
 template <typename RandomNumberEngine>
-struct poisson_generator: public event_generator {
+struct poisson_generator {
     using pse = postsynaptic_spike_event;
 
     poisson_generator(cell_member_type target,
@@ -198,23 +282,23 @@ struct poisson_generator: public event_generator {
         reset();
     }
 
-    postsynaptic_spike_event next() override {
+    postsynaptic_spike_event next() {
         return next_<t_stop_?
             postsynaptic_spike_event{target_, next_, weight_}:
             terminal_pse();
     }
 
-    void pop() override {
+    void pop() {
         next_ += exp_(rng_);
     }
 
-    void advance(time_type t0) override {
+    void advance(time_type t0) {
         while (next_<t0) {
             pop();
         }
     }
 
-    void reset() override {
+    void reset() {
         rng_ = reset_state_;
         next_ = t_start_;
         pop();
@@ -229,15 +313,7 @@ private:
     const time_type t_start_;
     const time_type t_stop_;
     time_type next_;
-
 };
-
-using event_generator_ptr = std::unique_ptr<event_generator>;
-
-template <typename T, typename... Args>
-event_generator_ptr make_event_generator(Args&&... args) {
-    return event_generator_ptr(new T(std::forward<Args>(args)...));
-}
 
 } // namespace arb
 

--- a/src/merge_events.hpp
+++ b/src/merge_events.hpp
@@ -40,7 +40,7 @@ void merge_events(time_type t0,
                   time_type t1,
                   const pse_vector& lc,
                   pse_vector& pending_events,
-                  std::vector<event_generator_ptr>& generators,
+                  std::vector<event_generator>& generators,
                   pse_vector& lf);
 
 namespace impl {
@@ -51,7 +51,7 @@ namespace impl {
         using key_val = std::pair<unsigned, postsynaptic_spike_event>;
 
     public:
-        tourney_tree(std::vector<event_generator_ptr>& input);
+        tourney_tree(std::vector<event_generator>& input);
         bool empty() const;
         bool empty(time_type t) const;
         postsynaptic_spike_event head() const;
@@ -73,7 +73,7 @@ namespace impl {
         unsigned next_power_2(unsigned x) const;
 
         std::vector<key_val> heap_;
-        const std::vector<event_generator_ptr>& input_;
+        std::vector<event_generator>& input_;
         unsigned leaves_;
         unsigned nodes_;
         unsigned n_lanes_;

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -85,10 +85,8 @@ void model::reset() {
     // Reset all event generators, and advance to t_.
     for (auto& lane: event_generators_) {
         for (auto& gen: lane) {
-            if (gen) {
-                gen->reset();
-                gen->advance(t_);
-            }
+            gen.reset();
+            gen.advance(t_);
         }
     }
 

--- a/src/model.hpp
+++ b/src/model.hpp
@@ -76,7 +76,7 @@ private:
     std::vector<cell_group_ptr> cell_groups_;
 
     // one set of event_generators for each local cell
-    std::vector<std::vector<event_generator_ptr>> event_generators_;
+    std::vector<std::vector<event_generator>> event_generators_;
 
     using local_spike_store_type = thread_private_spike_store;
     util::double_buffer<local_spike_store_type> local_spikes_;

--- a/src/recipe.hpp
+++ b/src/recipe.hpp
@@ -64,7 +64,7 @@ public:
     virtual cell_size_type num_targets(cell_gid_type) const { return 0; }
     virtual cell_size_type num_probes(cell_gid_type)  const { return 0; }
 
-    virtual std::vector<event_generator_ptr> event_generators(cell_gid_type) const {
+    virtual std::vector<event_generator> event_generators(cell_gid_type) const {
         return {};
     }
     virtual std::vector<cell_connection> connections_on(cell_gid_type) const {

--- a/tests/global_communication/test_domain_decomposition.cpp
+++ b/tests/global_communication/test_domain_decomposition.cpp
@@ -54,7 +54,7 @@ namespace {
             return {};
         }
 
-        std::vector<event_generator_ptr> event_generators(cell_gid_type) const override {
+        std::vector<event_generator> event_generators(cell_gid_type) const override {
             return {};
         }
 

--- a/tests/unit/test_event_generators.cpp
+++ b/tests/unit/test_event_generators.cpp
@@ -108,7 +108,7 @@ TEST(event_generator, regular_rounding) {
     time_type int_len = 5*dt;
     time_type t1 = t0 + int_len;
     time_type t2 = t1 + int_len;
-    auto gen = regular_generator(target, weight, t0, dt);
+    event_generator gen = regular_generator(target, weight, t0, dt);
 
     // Take the interval I_a: t ∈ [t0, t2)
     // And the two sub-interavls
@@ -147,7 +147,7 @@ TEST(event_generators, seq) {
         return pse_vector(in.begin()+b, in.begin()+e);
     };
 
-    seq_generator<pse_vector> gen(in);
+    event_generator gen = seq_generator<pse_vector>(in);
 
     // Test pop, next and reset.
     for (auto e: in) {

--- a/tests/unit/test_lif_cell_group.cpp
+++ b/tests/unit/test_lif_cell_group.cpp
@@ -81,7 +81,7 @@ public:
     probe_info get_probe(cell_member_type probe_id) const override {
         return {};
     }
-    std::vector<event_generator_ptr> event_generators(cell_gid_type) const override {
+    std::vector<event_generator> event_generators(cell_gid_type) const override {
         return {};
     }
 
@@ -134,7 +134,7 @@ public:
     probe_info get_probe(cell_member_type probe_id) const override {
         return {};
     }
-    std::vector<event_generator_ptr> event_generators(cell_gid_type) const override {
+    std::vector<event_generator> event_generators(cell_gid_type) const override {
         return {};
     }
 


### PR DESCRIPTION
Use type erasure tricks to remove abstract base class for `event_generator`.

This simplifies all the code that uses `event_generator`s (not radically, but it is simpler).
