### PR TITLE
Add padded allocator for aligned and padded vectors.

### DIFF
--- a/src/util/padded_alloc.hpp
+++ b/src/util/padded_alloc.hpp
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <memory>
+#include <system_error>
+#include <utility>
+
+#include <iostream>
+
+// Allocator with run-time alignment and padding guarantees.
+
+namespace arb {
+namespace util {
+
+template <typename T>
+struct padded_allocator {
+    using value_type = T;
+    using pointer = T*;
+    using propagate_on_container_copy_assignment = std::true_type;
+    using propagate_on_container_move_assignment = std::true_type;
+    using propagate_on_container_swap = std::true_type;
+    using is_always_equal = std::false_type;
+
+    padded_allocator() noexcept {}
+
+    template <typename U>
+    padded_allocator(const padded_allocator<U>& b) noexcept: alignment_(b.alignment()) {}
+
+    explicit padded_allocator(std::size_t alignment): alignment_(alignment) {
+        if (!alignment_ || (alignment_&(alignment_-1))) {
+            throw std::range_error("alignment must be positive power of two");
+        }
+    }
+
+    padded_allocator select_on_container_copy_construction() const noexcept {
+        return *this;
+    }
+
+    pointer allocate(std::size_t n) {
+        if (n>std::size_t(-1)/sizeof(T)) {
+            throw std::bad_alloc();
+        }
+
+        void* mem = nullptr;
+        std::size_t size = round_up(n*sizeof(T), alignment_);
+        std::size_t pm_align = std::max(alignment_, sizeof(void*));
+
+        if (auto err = posix_memalign(&mem, pm_align, size)) {
+            throw std::system_error(err, std::generic_category(), "posix_memalign");
+        }
+        return static_cast<pointer>(mem);
+    }
+
+    void deallocate(pointer p, std::size_t n) {
+        std::free(p);
+    }
+
+    bool operator==(const padded_allocator& a) const { return a.alignment_==alignment_; }
+    bool operator!=(const padded_allocator& a) const { return a.alignment_!=alignment_; }
+
+    std::size_t alignment() const { return alignment_; }
+
+private:
+    // Start address and one-past-the-end address a multiple of alignment:
+    std::size_t alignment_ = 1;
+
+    static std::size_t round_up(std::size_t v, std::size_t b) {
+        std::size_t m = v%b;
+        return v-m+(m? b: 0);
+    }
+};
+
+} // namespace util
+} // namespace arb

--- a/src/util/padded_alloc.hpp
+++ b/src/util/padded_alloc.hpp
@@ -8,6 +8,13 @@
 
 // Allocator with run-time alignment and padding guarantees.
 //
+// With an alignment value of `n`, any allocations will be
+// aligned to have a starting address of a multiple of `n`,
+// and the size of the allocation will be padded so that the
+// one-past-the-end address is also a multiple of `n`.
+//
+// Any alignment `n` specified must be a power of two.
+//
 // Assignment does not change the alignment property of the
 // allocator on the left hand side of the assignment, so that
 // e.g.

--- a/tests/ubench/CMakeLists.txt
+++ b/tests/ubench/CMakeLists.txt
@@ -4,6 +4,7 @@ include(ExternalProject)
 
 set(bench_sources
     accumulate_functor_values.cpp
+    default_construct.cpp
     event_setup.cpp
     event_binning.cpp
 )

--- a/tests/ubench/default_construct.cpp
+++ b/tests/ubench/default_construct.cpp
@@ -1,0 +1,109 @@
+// Compare value- vs default- initialized vector performance.
+
+// Explicitly undef NDEBUG for assert below.
+#undef NDEBUG
+
+#include <cassert>
+#include <vector>
+
+#include <benchmark/benchmark.h>
+
+#include <util/span.hpp>
+
+using arb::util::make_span;
+
+template <typename Allocator>
+struct default_construct_adaptor: Allocator {
+private:
+    using traits = typename std::allocator_traits<Allocator>;
+
+public:
+    using pointer = typename traits::pointer;
+    using value_type = typename traits::value_type;
+
+    default_construct_adaptor() noexcept {}
+
+    template <typename... Args>
+    default_construct_adaptor(Args&&... args):
+        Allocator(std::forward<Args...>(args...))
+    {}
+
+
+    template <typename U>
+    default_construct_adaptor(const default_construct_adaptor<U>& b) noexcept: Allocator(b) {}
+
+    void construct(pointer p) {
+        ::new (static_cast<void*>(p)) value_type;
+    }
+
+    template <typename... Args>
+    void construct(pointer p, Args&&... args) {
+        ::new (static_cast<void*>(p)) value_type(std::forward<Args...>(args)...);
+    }
+
+    template <typename U>
+    struct rebind {
+        using other = default_construct_adaptor<typename traits::template rebind_alloc<U>>;
+    };
+
+};
+
+
+template <typename Container>
+unsigned run_accumulate(std::size_t n) {
+    Container c(n);
+
+    unsigned s = 0;
+    for (unsigned& x: c) {
+        x = ++s;
+    }
+    s = 0;
+    for (unsigned x: c) {
+        s += x;
+    }
+    return s;
+}
+
+template <typename Container>
+unsigned run_accumulate_range_init(std::size_t n) {
+    auto values = make_span(1, n+1);
+    Container c(values.begin(), values.end());
+
+    unsigned s = 0;
+    for (unsigned x: c) {
+        s += x;
+    }
+    return s;
+}
+
+template <unsigned (*Fn)(std::size_t)>
+void bench_container(benchmark::State& state) {
+    std::size_t n = state.range(0);
+
+    while (state.KeepRunning()) {
+        benchmark::DoNotOptimize(Fn(n));
+    }
+
+    // check!
+    unsigned s = (n*(n+1))/2;
+    assert(s==Fn(n));
+}
+
+template <typename T>
+using dc_vector = std::vector<T, default_construct_adaptor<std::allocator<T>>>;
+
+auto bench_vector = bench_container<run_accumulate<std::vector<unsigned>>>;
+auto bench_dc_vector = bench_container<run_accumulate<dc_vector<unsigned>>>;
+
+auto bench_vector_range = bench_container<run_accumulate_range_init<std::vector<unsigned>>>;
+auto bench_dc_vector_range = bench_container<run_accumulate_range_init<dc_vector<unsigned>>>;
+
+
+BENCHMARK(bench_vector)->Range(1<<10, 1<<20);
+BENCHMARK(bench_dc_vector)->Range(1<<10, 1<<20);
+
+BENCHMARK(bench_vector_range)->Range(1<<10, 1<<20);
+BENCHMARK(bench_dc_vector_range)->Range(1<<10, 1<<20);
+
+BENCHMARK_MAIN();
+

--- a/tests/ubench/event_binning.cpp
+++ b/tests/ubench/event_binning.cpp
@@ -4,6 +4,7 @@
 // Keep this test as a prototype for testing, esp. when looking into binning.
 
 #include <random>
+#include <unordered_map>
 #include <vector>
 
 #include <event_queue.hpp>

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -61,6 +61,7 @@ set(TEST_SOURCES
     test_nop.cpp
     test_optional.cpp
     test_mechinfo.cpp
+    test_padded.cpp
     test_partition.cpp
     test_path.cpp
     test_point.cpp

--- a/tests/unit/instrument_malloc.hpp
+++ b/tests/unit/instrument_malloc.hpp
@@ -1,0 +1,138 @@
+#pragma once
+
+// Base class for scoped-instrumentation of glibc malloc.
+//
+// For the lifetime of a `with_instrumented_malloc` object,
+// global memory allocation hooks will be set so that
+// the virtual `on_malloc`, `on_realloc`, `on_memalign`
+// and `on_free` calls will be invoked before the corresponding
+// `malloc`, `realloc` etc. is executed.
+//
+// Scopes of `with_instrumented_malloc` may be nested, but:
+//   * Don't interleave lifetimes of these objects and expect things
+//     to work!
+//   * Don't try and create new `with_instrumented_malloc` instances
+//     from within an `on_malloc` callback (or others).
+//   * Definitely don't try and use this in a multithreaded context.
+//
+// Calling code should check CAN_INSTRUMENT_MALLOC preprocessor
+// symbol to see if this functionality is available.
+
+#include <cstddef>
+
+#if (__GLIBC__==2)
+#include <malloc.h>
+#define CAN_INSTRUMENT_MALLOC
+#endif
+
+namespace testing {
+
+#ifdef CAN_INSTRUMENT_MALLOC
+
+// For run-time, temporary intervention in the malloc-family calls,
+// there is still no better alternative than to use the
+// deprecated __malloc_hook pointers and friends. 
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
+// Totally not thread safe!
+struct with_instrumented_malloc {
+    with_instrumented_malloc() {
+        push();
+    }
+
+    ~with_instrumented_malloc() {
+        pop();
+    }
+
+    virtual void on_malloc(std::size_t, const void*) {}
+    virtual void on_realloc(void*, std::size_t, const void*) {}
+    virtual void on_free(void*, const void*) {}
+    virtual void on_memalign(std::size_t, std::size_t, const void*) {}
+
+private:
+    static with_instrumented_malloc*& instance() {
+        static with_instrumented_malloc* ptr = nullptr;
+        return ptr;
+    }
+
+    with_instrumented_malloc* prev_;
+    decltype(__malloc_hook) saved_malloc_hook_;
+    decltype(__realloc_hook) saved_realloc_hook_;
+    decltype(__free_hook) saved_free_hook_;
+    decltype(__memalign_hook) saved_memalign_hook_;
+
+    void push() {
+        saved_malloc_hook_ = __malloc_hook;
+        saved_realloc_hook_ = __realloc_hook;
+        saved_free_hook_ = __free_hook;
+        saved_memalign_hook_ = __memalign_hook;
+
+        prev_ = instance();
+        instance() = this;
+
+        __malloc_hook = malloc_hook;
+        __realloc_hook = realloc_hook;
+        __free_hook = free_hook;
+        __memalign_hook = memalign_hook;
+    }
+
+    void pop() {
+        instance() = prev_;
+        __malloc_hook = saved_malloc_hook_;
+        __realloc_hook = saved_realloc_hook_;
+        __free_hook = saved_free_hook_;
+        __memalign_hook = saved_memalign_hook_;
+    }
+
+    struct windback_guard {
+        with_instrumented_malloc* p;
+
+        windback_guard(): p(instance()) { p->pop(); }
+        ~windback_guard() { p->push(); }
+    };
+
+    static void* malloc_hook(std::size_t size, const void* caller) {
+        windback_guard g;
+        g.p->on_malloc(size, caller);
+        return malloc(size);
+    }
+
+    static void* realloc_hook(void* ptr, std::size_t size, const void* caller) {
+        windback_guard g;
+        g.p->on_realloc(ptr, size, caller);
+        return realloc(ptr, size);
+    }
+
+    static void free_hook(void* ptr, const void* caller) {
+        windback_guard g;
+        g.p->on_free(ptr, caller);
+        free(ptr);
+    }
+
+    static void* memalign_hook(std::size_t alignment, std::size_t size, const void* caller) {
+        windback_guard g;
+        g.p->on_memalign(alignment, size, caller);
+        return memalign(alignment, size);
+    }
+};
+
+#pragma GCC diagnostic pop
+
+#else
+
+struct with_instrumented_malloc {
+    with_instrumented_malloc() {
+        throw std::runtime_error("malloc instrumentation not supported\n");
+    }
+
+    virtual void on_malloc(std::size_t, const void*) {}
+    virtual void on_realloc(void*, std::size_t, const void*) {}
+    virtual void on_free(void*, const void*) {}
+    virtual void on_memalign(std::size_t, std::size_t, const void*) {}
+};
+
+#endif // ifdef CAN_INSTRUMENT_MALLOC
+
+} // namespace testing

--- a/tests/unit/test_padded.cpp
+++ b/tests/unit/test_padded.cpp
@@ -1,0 +1,132 @@
+#include <cstdint>
+
+#if (__GLIBC__==2)
+#include <malloc.h>
+#define INSTRUMENT_MALLOC
+#endif
+
+#include <util/padded_alloc.hpp>
+
+#include "../gtest.h"
+#include "common.hpp"
+#include "instrument_malloc.hpp"
+
+using arb::util::padded_allocator;
+
+template <typename T>
+using pvector = std::vector<T, padded_allocator<T>>;
+
+static bool is_aligned(void* p, std::size_t k) {
+    auto addr = reinterpret_cast<std::uintptr_t>(p);
+    return !(addr&(k-1));
+}
+
+TEST(padded_vector, alignment) {
+    padded_allocator<double> pa(1024);
+    pvector<double> a(101, pa);
+
+    EXPECT_EQ(1024u, a.get_allocator().alignment());
+    EXPECT_TRUE(is_aligned(a.data(), 1024));
+}
+
+TEST(padded_vector, allocator_propagation) {
+    padded_allocator<double> pa(1024);
+    pvector<double> a(101, pa);
+
+    EXPECT_EQ(pa, a.get_allocator());
+
+    pvector<double> b(101);
+    auto pb = b.get_allocator();
+
+    EXPECT_EQ(1u, pb.alignment());
+    EXPECT_NE(pa, pb);
+
+    b = a;
+    EXPECT_EQ(1024u, b.get_allocator().alignment());
+    EXPECT_TRUE(is_aligned(b.data(), 1024));
+    EXPECT_EQ(pa, b.get_allocator());
+    EXPECT_NE(pb, b.get_allocator());
+
+    pvector<double> c;
+    c = std::move(a);
+
+    EXPECT_EQ(pa, c.get_allocator());
+}
+
+
+#ifdef INSTRUMENT_MALLOC
+
+struct count_allocs: testing::with_instrumented_malloc {
+    unsigned n_malloc = 0;
+    unsigned n_realloc = 0;
+    unsigned n_memalign = 0;
+
+    std::size_t last_malloc = -1;
+    std::size_t last_realloc = -1;
+    std::size_t last_memalign = -1;
+
+    void on_malloc(std::size_t size, const void*) override {
+        ++n_malloc;
+        last_malloc = size;
+    }
+
+    void on_realloc(void*, std::size_t size, const void*) override {
+        ++n_realloc;
+        last_realloc = size;
+    }
+
+    void on_memalign(std::size_t, std::size_t size, const void*) override {
+        ++n_memalign;
+        last_memalign = size;
+    }
+};
+
+TEST(padded_vector, instrumented) {
+    count_allocs A;
+
+    padded_allocator<double> pad256(256), pad32(32);
+    pvector<double> v1(303, pad256);
+
+    unsigned expected_v1_alloc = 303*sizeof(double);
+    expected_v1_alloc = expected_v1_alloc%256? 256*(1+expected_v1_alloc/256): expected_v1_alloc;
+
+    EXPECT_EQ(1u, A.n_memalign);
+    EXPECT_EQ(0u, A.n_malloc);
+    EXPECT_EQ(0u, A.n_realloc);
+    EXPECT_EQ(expected_v1_alloc, A.last_memalign);
+
+    pvector<double> v2(pad32);
+    v2 = std::move(v1); // move should move allocator and not copy
+
+    EXPECT_EQ(1u, A.n_memalign);
+    EXPECT_EQ(0u, A.n_malloc);
+    EXPECT_EQ(0u, A.n_realloc);
+
+    pvector<double> v3(700, pad256);
+
+    EXPECT_EQ(2u, A.n_memalign);
+    EXPECT_EQ(0u, A.n_malloc);
+    EXPECT_EQ(0u, A.n_realloc);
+
+    v3 = v2; // same alignment, larger size => shouldn't need to allocate
+
+    EXPECT_EQ(2u, A.n_memalign);
+    EXPECT_EQ(0u, A.n_malloc);
+    EXPECT_EQ(0u, A.n_realloc);
+
+    pvector<double> v4(700, pad32);
+
+    EXPECT_EQ(3u, A.n_memalign);
+    EXPECT_EQ(0u, A.n_malloc);
+    EXPECT_EQ(0u, A.n_realloc);
+    EXPECT_NE(expected_v1_alloc, A.last_memalign);
+
+    v4 = v2; // different alignment, so will have to reallocate
+
+    EXPECT_EQ(4u, A.n_memalign);
+    EXPECT_EQ(0u, A.n_malloc);
+    EXPECT_EQ(0u, A.n_realloc);
+    EXPECT_EQ(expected_v1_alloc, A.last_memalign);
+}
+
+#endif // ifdef INSTRUMENT_MALLOC


### PR DESCRIPTION
Padded vectors with run-time padding/alignment guarantees will form the basis of the storage class for the new CPU and SIMD generated mechanisms.

* Add `padded_allocator` that aligns and pads allocations.
* Make microbenchmark for `default_construct_adaptor` that overrides the allocator construct() to default- instead of value-initialization on values.
* Add `with_instrumented_malloc` class for tracking malloc, realloc, etc. calls.
* Add unit tests for `padded_allocator`.