### PR TITLE
rename `arb::model` to `arb::simulation`

### DIFF
--- a/doc/profiler.rst
+++ b/doc/profiler.rst
@@ -2,7 +2,8 @@ Profiler
 ========
 
 The Arbor library has a built-in profiler for fine-grained timings of regions of interest in the code.
-The time stepping code in ``arb::model`` has been instrumented, so by enabling profiler support at compile time, users of the library can generate profile reports from calls to ``arb::model::run()``.
+The time stepping code in ``arb::simulation`` has been instrumented, so by enabling profiler support at
+compile time, users of the library can generate profile reports from calls to ``arb::simulation::run()``.
 
 Compilation
 -----------
@@ -184,7 +185,7 @@ and the profiler regions can be reset.
         }
 
 After a call to ``util::profiler_clear``, all counters and timers are set to zero.
-This could be used, for example, to generate seperate profiler reports for model building and model executation phases of a simulation.
+This could be used, for example, to generate seperate profiler reports for model building and model executation phases.
 
 Profiler Output
 ~~~~~~~~~~~~~~~

--- a/doc/sampling_api.rst
+++ b/doc/sampling_api.rst
@@ -27,7 +27,7 @@ Probes
 ------
 
 Probes are specified in the recipe objects that are used to initialize a
-model; the specification of the item or value that is subjected to a
+simulation; the specification of the item or value that is subjected to a
 probe will be specific to a particular cell type.
 
 .. container:: api-code
@@ -134,7 +134,7 @@ Model and cell group interface
 ------------------------------
 
 Polling rates, policies and sampler functions are set through the
-``model`` interface, after construction from a recipe.
+``simulation`` interface, after construction from a recipe.
 
 .. container:: api-code
 
@@ -143,15 +143,15 @@ Polling rates, policies and sampler functions are set through the
             using sampler_association_handle = std::size_t;
             using cell_member_predicate = std::function<bool (cell_member_type)>;
 
-            sampler_association_handle model::add_sampler(
+            sampler_association_handle simulation::add_sampler(
                 cell_member_predicate probe_ids,
                 schedule sched,
                 sampler_function fn,
                 sampling_policy policy = sampling_policy::lax);
 
-            void model::remove_sampler(sampler_association_handle);
+            void simulation::remove_sampler(sampler_association_handle);
 
-            void model::remove_all_samplers();
+            void simulation::remove_all_samplers();
 
 Multiple samplers can then be associated with the same probe locations.
 The handle returned is only used for managing the lifetime of the
@@ -179,7 +179,7 @@ minimizes sampling overhead and which will not change the numerical
 behaviour of the simulation. Other policies may be implemented in the
 future, e.g. ``interpolated`` or ``exact``.
 
-The model object will pass on the sampler setting request to the cell
+The simulation object will pass on the sampler setting request to the cell
 group that owns the given probe id. The ``cell_group`` interface will be
 correspondingly extended:
 
@@ -262,7 +262,7 @@ The ``schedule`` class and its implementations are found in ``schedule.hpp``.
 Helper classes for probe/sampler management
 -------------------------------------------
 
-The ``model`` and ``mc_cell_group`` classes use classes defined in ``scheduler_map.hpp`` to simplify
+The ``simulation`` and ``mc_cell_group`` classes use classes defined in ``scheduler_map.hpp`` to simplify
 the management of sampler--probe associations and probe metdata.
 
 ``sampler_association_map`` wraps an ``unordered_map`` between sampler assocation

--- a/example/generators/event_gen.cpp
+++ b/example/generators/event_gen.cpp
@@ -17,7 +17,7 @@
 #include <event_generator.hpp>
 #include <hardware/node_info.hpp>
 #include <load_balance.hpp>
-#include <model.hpp>
+#include <simulation.hpp>
 #include <recipe.hpp>
 #include <simple_sampler.hpp>
 
@@ -133,7 +133,7 @@ int main() {
     auto decomp = arb::partition_load_balance(recipe, node);
 
     // Construct the model.
-    arb::model model(recipe, decomp);
+    arb::simulation sim(recipe, decomp);
 
     // Set up the probe that will measure voltage in the cell.
 
@@ -144,10 +144,10 @@ int main() {
     // This is where the voltage samples will be stored as (time, value) pairs
     arb::trace_data<double> voltage;
     // Now attach the sampler at probe_id, with sampling schedule sched, writing to voltage
-    model.add_sampler(arb::one_probe(probe_id), sched, arb::make_simple_sampler(voltage));
+    sim.add_sampler(arb::one_probe(probe_id), sched, arb::make_simple_sampler(voltage));
 
-    // Run the model for 1 s (1000 ms), with time steps of 0.01 ms.
-    model.run(50, 0.01);
+    // Run the simulation for 1 s (1000 ms), with time steps of 0.01 ms.
+    sim.run(50, 0.01);
 
     // Write the samples to a json file.
     write_trace_json(voltage);

--- a/example/generators/readme.md
+++ b/example/generators/readme.md
@@ -45,7 +45,8 @@ default `recipe::connections_on(gid)` method can use the default implementation,
 which returns an empty list of connections for a cell.
 
 Above you can see the definition of `recipe::num_cells()`, which is trivial for this model, which has only once cell.
-The `recipe::get_cell_description(gid)` and `recipe::get_cell_kind(gid)` methods are defined to return a single compartment cell with one synapse, and a `arb::cell_kind::cable1d_neuron` respectively:
+The `recipe::get_cell_description(gid)` and `recipe::get_cell_kind(gid)` methods are defined to return a single
+compartment cell with one synapse, and a `arb::cell_kind::cable1d_neuron` respectively:
 
 ```C++
     // Return an arb::cell that describes a single compartment cell with
@@ -139,8 +140,8 @@ To visualise the result of our experiment, we want to sample the voltage in our 
 There are three parts to this process.
 
 1. Define the a `probe` in the recipe, which describes the location and variable to be sampled, i.e. the soma and voltage respectively for this example.
-2. Attach a sampler to this probe once the model has been created.
-3. Write the sampled values to a JSON file once the model has been run.
+2. Attach a sampler to this probe once the simulation has been created.
+3. Write the sampled values to a JSON file once the simulation has been run.
 
 #### 1. Define probe in recipe
 
@@ -166,9 +167,9 @@ In our case, the cell has one probe, which refers to the voltage at the soma.
     }
 ```
 
-#### 2. Attach sampler to model
+#### 2. Attach sampler to simulation
 
-Once the model has been created, the model has internal state that tracks the value of the voltage at the probe location described by the recipe.
+Once the simulation has been created, the simulation has internal state that tracks the value of the voltage at the probe location described by the recipe.
 We must attach a sampler to this probe to get sample values.
 
 The sampling interface is rich, and can be extended in many ways.
@@ -186,10 +187,10 @@ For our simple use case there are three bits of information that need to be prov
     // Where the voltage samples will be stored as (time, value) pairs
     arb::trace_data<double> voltage;
     // Now attach the sampler:
-    model.add_sampler(arb::one_probe(probe_id), sched, arb::make_simple_sampler(voltage));
+    sim.add_sampler(arb::one_probe(probe_id), sched, arb::make_simple_sampler(voltage));
 ```
 
-When the model is run, the `simple_sampler` that we attached to the probe will store the sample values as (time, voltage) pairs in the `voltage` vector.
+When the simulation is run, the `simple_sampler` that we attached to the probe will store the sample values as (time, voltage) pairs in the `voltage` vector.
 
 #### 3. Output to JSON
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,7 +11,7 @@ set(BASE_SOURCES
     hardware/node_info.cpp
     hardware/power.cpp
     merge_events.cpp
-    model.cpp
+    simulation.cpp
     morphology.cpp
     partition_load_balance.cpp
     profiling/memory_meter.cpp

--- a/src/merge_events.cpp
+++ b/src/merge_events.cpp
@@ -6,7 +6,6 @@
 #include <cell_group_factory.hpp>
 #include <domain_decomposition.hpp>
 #include <merge_events.hpp>
-#include <model.hpp>
 #include <recipe.hpp>
 #include <util/filter.hpp>
 #include <util/span.hpp>

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -20,12 +20,12 @@
 
 namespace arb {
 
-class model {
+class simulation {
 public:
     using communicator_type = communication::communicator<communication::global_policy>;
     using spike_export_function = std::function<void(const std::vector<spike>&)>;
 
-    model(const recipe& rec, const domain_decomposition& decomp);
+    simulation(const recipe& rec, const domain_decomposition& decomp);
 
     void reset();
 
@@ -55,8 +55,8 @@ public:
     void set_local_spike_callback(spike_export_function export_callback);
 
     // Add events directly to targets.
-    // Must be called before calling model::run, and must contain events that
-    // are to be delivered at or after the current model time.
+    // Must be called before calling simulation::run, and must contain events that
+    // are to be delivered at or after the current simulation time.
     void inject_events(const pse_vector& events);
 
 private:

--- a/tests/unit/test_fvm_multi.cpp
+++ b/tests/unit/test_fvm_multi.cpp
@@ -8,7 +8,7 @@
 #include <fvm_multicell.hpp>
 #include <load_balance.hpp>
 #include <math.hpp>
-#include <model.hpp>
+#include <simulation.hpp>
 #include <recipe.hpp>
 #include <sampler_map.hpp>
 #include <sampling.hpp>
@@ -584,7 +584,7 @@ TEST(fvm_multi, specialized_mechs) {
         float times[] = {10.f, 20.f};
 
         auto decomp = partition_load_balance(rec, hw::node_info{1u, 0u});
-        model sim(rec, decomp);
+        simulation sim(rec, decomp);
         sim.add_sampler(all_probes, explicit_schedule(times), sampler);
         sim.run(30.0, 1.f/1024);
 

--- a/tests/unit/test_lif_cell_group.cpp
+++ b/tests/unit/test_lif_cell_group.cpp
@@ -4,7 +4,7 @@
 #include <lif_cell_description.hpp>
 #include <lif_cell_group.hpp>
 #include <load_balance.hpp>
-#include <model.hpp>
+#include <simulation.hpp>
 #include <recipe.hpp>
 #include <rss_cell.hpp>
 #include <rss_cell_group.hpp>
@@ -161,7 +161,7 @@ TEST(lif_cell_group, spikes) {
     nd.num_cpu_cores = threading::num_threads();
 
     auto decomp = partition_load_balance(recipe, nd);
-    model m(recipe, decomp);
+    simulation sim(recipe, decomp);
 
     std::vector<postsynaptic_spike_event> events;
 
@@ -176,14 +176,14 @@ TEST(lif_cell_group, spikes) {
     // event, should thus trigger new spike (first neuron).
     events.push_back({{0, 0}, 50, 1000});
 
-    m.inject_events(events);
+    sim.inject_events(events);
 
     time_type tfinal = 100;
     time_type dt = 0.01;
-    m.run(tfinal, dt);
+    sim.run(tfinal, dt);
 
     // we expect 4 spikes: 2 by both neurons
-    EXPECT_EQ(4u, m.num_spikes());
+    EXPECT_EQ(4u, sim.num_spikes());
 }
 
 TEST(lif_cell_group, ring)
@@ -202,19 +202,19 @@ TEST(lif_cell_group, ring)
     auto recipe = ring_recipe(num_lif_cells, weight, delay);
     auto decomp = partition_load_balance(recipe, nd);
 
-    // Creates a model with a ring recipe of lif neurons
-    model mod(recipe, decomp);
+    // Creates a simulation with a ring recipe of lif neurons
+    simulation sim(recipe, decomp);
 
     std::vector<spike> spike_buffer;
 
-    mod.set_global_spike_callback(
+    sim.set_global_spike_callback(
         [&spike_buffer](const std::vector<spike>& spikes) {
             spike_buffer.insert(spike_buffer.end(), spikes.begin(), spikes.end());
         }
     );
 
     // Runs the simulation for simulation_time with given timestep
-    mod.run(simulation_time, 0.01);
+    sim.run(simulation_time, 0.01);
     // The total number of cells in all the cell groups.
     // There is one additional fake cell (regularly spiking cell).
     EXPECT_EQ(num_lif_cells + 1u, recipe.num_cells());

--- a/tests/unit/test_merge_events.cpp
+++ b/tests/unit/test_merge_events.cpp
@@ -2,7 +2,6 @@
 
 #include <event_queue.hpp>
 #include <merge_events.hpp>
-#include <model.hpp>
 
 using namespace arb;
 

--- a/tests/validation/convergence_test.hpp
+++ b/tests/validation/convergence_test.hpp
@@ -2,7 +2,8 @@
 
 #include <vector>
 
-#include <model.hpp>
+#include <simulation.hpp>
+#include <schedule.hpp>
 #include <sampling.hpp>
 #include <simple_sampler.hpp>
 #include <util/filter.hpp>
@@ -72,7 +73,7 @@ public:
         }
     }
 
-    void run(model& m, Param p, float sample_dt, float t_end, float dt, const std::vector<float>& excl) {
+    void run(simulation& sim, Param p, float sample_dt, float t_end, float dt, const std::vector<float>& excl) {
         struct sampler_state {
             sampler_association_handle h; // Keep these for clean up at end.
             const char* label;
@@ -88,10 +89,10 @@ public:
             auto& entry = samplers.back();
 
             entry.label = pl.label;
-            entry.h = m.add_sampler(one_probe(pl.probe_id), regular_schedule(sample_dt), simple_sampler<double>(entry.trace));
+            entry.h = sim.add_sampler(one_probe(pl.probe_id), regular_schedule(sample_dt), simple_sampler<double>(entry.trace));
         }
 
-        m.run(t_end, dt);
+        sim.run(t_end, dt);
 
         for (auto& entry: samplers) {
             std::string label = entry.label;
@@ -114,7 +115,7 @@ public:
 
         // Remove added samplers.
         for (const auto& entry: samplers) {
-            m.remove_sampler(entry.h);
+            sim.remove_sampler(entry.h);
         }
     }
 

--- a/tests/validation/validate_ball_and_stick.cpp
+++ b/tests/validation/validate_ball_and_stick.cpp
@@ -5,7 +5,7 @@
 #include <load_balance.hpp>
 #include <hardware/node_info.hpp>
 #include <hardware/gpu.hpp>
-#include <model.hpp>
+#include <simulation.hpp>
 #include <recipe.hpp>
 #include <segment.hpp>
 #include <simple_sampler.hpp>
@@ -77,9 +77,9 @@ void run_ncomp_convergence_test(
 
         hw::node_info nd(1, backend==backend_kind::gpu? 1: 0);
         auto decomp = partition_load_balance(rec, nd);
-        model m(rec, decomp);
+        simulation sim(rec, decomp);
 
-        runner.run(m, ncomp, sample_dt, t_end, dt, exclude);
+        runner.run(sim, ncomp, sample_dt, t_end, dt, exclude);
     }
     runner.report();
     runner.assert_all_convergence();

--- a/tests/validation/validate_compartment_policy.cpp
+++ b/tests/validation/validate_compartment_policy.cpp
@@ -5,7 +5,7 @@
 
 #include <common_types.hpp>
 #include <cell.hpp>
-#include <model.hpp>
+#include <simulation.hpp>
 #include <recipe.hpp>
 #include <simple_sampler.hpp>
 #include <util/rangeutil.hpp>
@@ -32,8 +32,8 @@ using namespace arb;
  */
 
 template <typename CompPolicy>
-std::vector<trace_data> run_model(const cell& c, float sample_dt, float t_end, float dt) {
-    model<fvm::fvm_multicell<double, cell_local_size_type, div_compartment_by_ends>> m{singleton_recipe(c)};
+std::vector<trace_data> run_simulation(const cell& c, float sample_dt, float t_end, float dt) {
+    simulation<fvm::fvm_multicell<double, cell_local_size_type, div_compartment_by_ends>> m{singleton_recipe(c)};
 
     const auto& probes = m.probes();
     std::size_t n_probes = probes.size();
@@ -59,9 +59,9 @@ void run_test(cell&& c) {
     float t_end = 100;
     float dt = 0.001;
 
-    auto traces_by_ends = run_model<div_compartment_by_ends>(c, sample_dt, t_end, dt);
-    auto traces_sampler = run_model<div_compartment_sampler>(c, sample_dt, t_end, dt);
-    auto traces_integrator = run_model<div_compartment_integrator>(c, sample_dt, t_end, dt);
+    auto traces_by_ends = run_simulation<div_compartment_by_ends>(c, sample_dt, t_end, dt);
+    auto traces_sampler = run_simulation<div_compartment_sampler>(c, sample_dt, t_end, dt);
+    auto traces_integrator = run_simulation<div_compartment_integrator>(c, sample_dt, t_end, dt);
 
     auto n_trace = traces_by_ends.size();
     ASSERT_GT(n_trace, 0);

--- a/tests/validation/validate_kinetic.cpp
+++ b/tests/validation/validate_kinetic.cpp
@@ -7,7 +7,7 @@
 #include <hardware/node_info.hpp>
 #include <hardware/gpu.hpp>
 #include <load_balance.hpp>
-#include <model.hpp>
+#include <simulation.hpp>
 #include <recipe.hpp>
 #include <simple_sampler.hpp>
 #include <util/rangeutil.hpp>
@@ -43,7 +43,7 @@ void run_kinetic_dt(
 
     hw::node_info nd(1, backend==backend_kind::gpu? 1: 0);
     auto decomp = partition_load_balance(rec, nd);
-    model model(rec, decomp);
+    simulation sim(rec, decomp);
 
     auto exclude = stimulus_ends(c);
 
@@ -54,9 +54,9 @@ void run_kinetic_dt(
             double oo_dt = base/multiple;
             if (oo_dt>max_oo_dt) goto end;
 
-            model.reset();
+            sim.reset();
             float dt = float(1./oo_dt);
-            runner.run(model, dt, sample_dt, t_end, dt, exclude);
+            runner.run(sim, dt, sample_dt, t_end, dt, exclude);
         }
     }
 

--- a/tests/validation/validate_soma.cpp
+++ b/tests/validation/validate_soma.cpp
@@ -5,7 +5,7 @@
 #include <hardware/gpu.hpp>
 #include <hardware/node_info.hpp>
 #include <load_balance.hpp>
-#include <model.hpp>
+#include <simulation.hpp>
 #include <recipe.hpp>
 #include <simple_sampler.hpp>
 #include <util/rangeutil.hpp>
@@ -32,7 +32,7 @@ void validate_soma(backend_kind backend) {
 
     hw::node_info nd(1, backend==backend_kind::gpu? 1: 0);
     auto decomp = partition_load_balance(rec, nd);
-    model m(rec, decomp);
+    simulation sim(rec, decomp);
 
     nlohmann::json meta = {
         {"name", "membrane voltage"},
@@ -54,9 +54,9 @@ void validate_soma(backend_kind backend) {
             double oo_dt = base/multiple;
             if (oo_dt>max_oo_dt) goto end;
 
-            m.reset();
+            sim.reset();
             float dt = float(1./oo_dt);
-            runner.run(m, dt, sample_dt, t_end, dt, {});
+            runner.run(sim, dt, sample_dt, t_end, dt, {});
         }
     }
 end:

--- a/tests/validation/validate_synapses.cpp
+++ b/tests/validation/validate_synapses.cpp
@@ -4,7 +4,7 @@
 #include <hardware/gpu.hpp>
 #include <json/json.hpp>
 #include <load_balance.hpp>
-#include <model.hpp>
+#include <simulation.hpp>
 #include <recipe.hpp>
 #include <simple_sampler.hpp>
 #include <util/path.hpp>
@@ -73,11 +73,11 @@ void run_synapse_test(
         rec.add_probe(0, 0, cell_probe_address{{1, 1.0}, cell_probe_address::membrane_voltage});
 
         auto decomp = partition_load_balance(rec, nd);
-        model m(rec, decomp);
+        simulation sim(rec, decomp);
 
-        m.inject_events(synthetic_events);
+        sim.inject_events(synthetic_events);
 
-        runner.run(m, ncomp, sample_dt, t_end, dt, exclude);
+        runner.run(sim, ncomp, sample_dt, t_end, dt, exclude);
     }
     runner.report();
     runner.assert_all_convergence();


### PR DESCRIPTION
The name `arb::model` did not clearly describe the role of this class.
Renaming it `arb::simulator` shows more clearly that this is an instantiation of a model, for the purpose of running a simulation, as opposed to `arb::recipe` which is a description of a model with no information about how or where the model will run/be simulated.

* rename `model.{hpp,cpp}` to `simulation,{hpp,cpp}`
* rename `arb::model` to `arb::simulation`
* update all files that include or refer these files/types
* update docs to more clearly define model and simulation.
