### PR TITLE
Domain decomposition and simulation C++ API docs

### DIFF
--- a/doc/cpp_domdec.rst
+++ b/doc/cpp_domdec.rst
@@ -1,0 +1,180 @@
+Domain Decomposition
+====================
+
+Definitions
+-----------
+
+Domain decomposition
+    A description of the distribution of the model over the available
+    computational resources. In practice, the description partitions the
+    cells in the model as follows:
+
+        * group the cells into *cell groups* of the same kind of cell;
+        * assign each cell group to either a CPU core or GPU on a specific MPI rank.
+
+    The number of cells in each cell group depends on different factors,
+    including the type of the cell, and whether the cell group will run on a CPU
+    core or the GPU.
+
+    See :cpp:class:`arb::domain_decimposition`.
+
+Load balancer
+    A distributed algorithm that determines the domain decomposition using the
+    model recipe and and description of the available computational resources as
+    inputs.
+
+    See :cpp:func:`arb::partition_load_balance`.
+
+Hardware
+--------
+
+.. cpp:namespace:: arb::hw
+
+.. cpp:class:: node_info
+
+    Information about the computational resources available to a simulation, typically a
+    subset of the resources available on a physical hardware node.
+    When used for distributed simulations, where a model will be distributed over more than
+    one node, a :cpp:class:`hw::node_info` represents the resources available to the local
+    MPI rank.
+
+    .. container:: example-code
+
+        .. code-block:: cpp
+
+            // Make node that uses one thread for each available hardware thread,
+            // and one GPU if any GPUs are available.
+            hw::node_info node;
+            node.num_cpu_cores = threading::num_threads();
+            node.num_gpus = hw::num_gpus()>0? 1: 0;
+
+    .. cpp:function:: node_info() = default
+
+        Default hardware description with 1 CPU core and no GPUs.
+
+    .. cpp:function:: node_info(unsigned cores, unsigned gpus)
+
+        Constructor that sets the number of :cpp:var:`cores` and :cpp:var:`gpus` available.
+
+    .. cpp:member:: unsigned num_cpu_cores = 1
+
+        The number of CPU cores available.
+
+        By default it is assumed that there is one core available.
+
+    .. cpp:member:: unsigned num_gpus = 0
+
+        The number of GPUs available.
+
+        By default it is assumed that there are no GPUs.
+
+Load Balancers
+--------------
+
+Load balancing generates a :cpp:class:`domain_decomposition` given a :cpp:class:`recipe`
+and a description of the hardware on which the model will run. Currently Arbor provides
+one load balancer, :cpp:func:`partition_load_balance`, and more will be added over time.
+
+If the model is distributed with MPI, the partitioning of cells is distributed,
+and MPI communication is used to generate the domain decomposition.
+The returned :cpp:class:`domain_decomposition` describes the cell groups
+on the local MPI rank.
+
+.. Note::
+    Often power users know their model and the hardware resources that
+    they are running on very well, and know best how to partition their model
+    workload to get optimal performance.
+    The :cpp:class:`domain_decomposition` type is kept very simple, and is
+    independent of any load balancing algorithm, so power users can supply their
+    own domain decomposition without using one of the built-in load balancers.
+
+.. cpp:namespace:: arb
+
+.. cpp:function:: domain_decomposition partition_load_balance(const recipe& rec, hw::node_info nd)
+
+    Makes an :cpp:class:`domain_decomposition` that distributes the cells
+    in the model described by :cpp:var:`rec` over the hardware resources described
+    by `hw::node_info`.
+
+Decomposition
+-------------
+
+Documentation for the data structures used to describe domain decompositions.
+
+.. cpp:namespace:: arb
+
+.. cpp:enum-class:: backend_kind
+
+    Used to indicate which hardware backend to use for running a :cpp:class:`cell_group`.
+
+    .. cpp:enumerator:: multicore
+
+        Use multicore backend for all computation.
+
+    .. cpp:enumerator:: gpu
+
+        Use gpu back end when supported.
+
+        .. Note::
+            Can only be set if the :cpp:class:`cell_group` type supports the GPU backend.
+
+.. cpp:class:: domain_decomposition
+
+    Meta data that describes a domain decomposition.
+    Solely responsible for describing the distribution of cells across cell groups and domains.
+    A load balancing algorithm generates the domain decomposition,
+    for example see :cpp:func:`partition_load_balance`.
+
+    .. cpp:function:: bool is_local_gid(cell_gid_type gid) const
+
+        Tests whether a gid is on the local domain.
+
+    .. cpp:member:: std::function<int(cell_gid_type)> gid_domain
+
+        Return the domain id of cell with gid.
+        Supplied by the load balancing algorithm that generates the domain
+        decomposition.
+
+    .. cpp:member:: int num_domains
+
+        Number of domains that the model is distributed over.
+
+    .. cpp:member:: int domain_id
+
+        The index of the local domain.
+        Equal to 0 for non-distributed models, and corresponds to the MPI rank for distributed runs.
+
+    .. cpp:member:: cell_size_type num_local_cells
+
+        Total number of cells in the local domain.
+
+    .. cpp:member:: cell_size_type num_global_cells
+
+        Total number of cells in the global model
+        (sum of :cpp:member:`num_local_cells` over all domains).
+
+    .. cpp:member:: std::vector<group_description> groups
+
+        Descriptions of the cell groups on the local domain.
+
+.. cpp:class:: group_decomposition
+
+    The indexes of a set of cells of the same kind that are group together in a
+    cell group in a :cpp:class:`arb::simulation`.
+
+    .. cpp:function:: group_description(cell_kind k, std::vector<cell_gid_type> g, backend_kind b)
+
+        Constructor.
+
+    .. cpp:member:: const cell_kind kind
+
+        The kind of cell in the group.
+
+    .. cpp:member:: const std::vector<cell_gid_type> gids
+
+        The gids of the cells in the cell group, sorted in ascending order.
+
+    .. cpp:member:: const backend_kind backend
+
+        The back end on which the cell group is to run.
+

--- a/doc/cpp_domdec.rst
+++ b/doc/cpp_domdec.rst
@@ -161,9 +161,9 @@ Documentation for the data structures used to describe domain decompositions.
 
     .. cpp:member:: std::function<int(cell_gid_type)> gid_domain
 
-        A function can be used to query the domain id that a cell assigned to
+        A function for querying the domain id that a cell assigned to
         (using global identifier :cpp:var:`gid`).
-        It is a pure function, that is it has no side effects, and hence is
+        It must be a pure function, that is it has no side effects, and hence is
         thread safe.
 
     .. cpp:member:: int num_domains

--- a/doc/cpp_intro.rst
+++ b/doc/cpp_intro.rst
@@ -8,4 +8,4 @@ implement models.
 Arbor makes a distinction between the **description** of a model, and the
 **execution** of a model.
 
-A :cpp:type:`arb::recipe` describes a model.
+A :cpp:type:`arb::recipe` describes a model, and a :cpp:type:`arb::simulation` is an executable instatiation of a model.

--- a/doc/cpp_recipe.rst
+++ b/doc/cpp_recipe.rst
@@ -1,7 +1,7 @@
 Recipes
 ===============
 
-An Arbor recipe is a description of a model. The recipe is queried during the model
+An Arbor **recipe** is a description of a model. The recipe is queried during the model
 building phase to provide cell information, such as:
 
   * the number of cells in the model;
@@ -52,9 +52,8 @@ The steps of building a simulation from a recipe are:
 Best Practices
 --------------
 
-Here is a set of rules of tumb to keep in mind when making recipes. The first is
-mandatory, and following the others as closely as possible will lead to better
-performance.
+Here is a set of rules of thumb to keep in mind when making recipes. The first is
+mandatory, and following the others will lead to better performance.
 
 .. topic:: Stay thread safe
 
@@ -68,13 +67,13 @@ performance.
 .. topic:: Be lazy
 
     A recipe does not have to contain a complete description of the model in
-    memory; it should precompute as little as possible, and use
+    memory; precompute as little as possible, and use
     `lazy evaluation <https://en.wikipedia.org/wiki/Lazy_evaluation>`_ to generate
     information only when requested.
     This has multiple benefits, including:
 
         * thread safety;
-        * minimising memory footprint of recipe.
+        * minimising the memory footprint of the recipe.
 
 .. topic:: Think of the cells
 

--- a/doc/cpp_simulation.rst
+++ b/doc/cpp_simulation.rst
@@ -57,8 +57,8 @@ Class Documentation
 
         * **Advance model state** from one time to another and reset model
           state to its original state before simulation was started.
-        * **I/O** interface for sampling simulation variables (e.g. compartment voltage
-          and current) and spike output.
+        * **I/O** interface for sampling simulation state during execution
+          (e.g. compartment voltage and current) and spike output.
 
     **Types:**
 
@@ -88,8 +88,7 @@ Class Documentation
 
     .. cpp:function:: void reset()
 
-        Reset the state of the simulation to its original state before
-        :cpp:func:`simulation::run` was called.
+        Reset the state of the simulation to its initial state.
 
     .. cpp:function:: time_type run(time_type tfinal, time_type dt)
 
@@ -125,15 +124,19 @@ Class Documentation
 
     .. cpp:function:: std::size_t num_spikes() const
 
-        The total number of spikes that occurred since either construction or
-        last resetting the model.
+        The total number of spikes generated since either construction or
+        the last call to :cpp:func:`simulation::reset`.
 
     .. cpp:function:: void set_global_spike_callback(spike_export_function export_callback)
 
-        Register a callback that will perform an export of the global spike vector.
+        Register a callback that will periodically be passed a vector with all of
+        the spikes generated over all domains (the global spike vector) since
+        the last call.
         Will be called on the MPI rank/domain with id 0.
 
     .. cpp:function:: void set_local_spike_callback(spike_export_function export_callback)
 
-        Register a callback that will perform an export of the rank local spike vector.
+        Register a callback that will periodically be passed a vector with all of
+        the spikes generated on the local domain (the local spike vector) since
+        the last call.
         Will be called on each MPI rank/domain with a copy of the local spikes.

--- a/doc/cpp_simulation.rst
+++ b/doc/cpp_simulation.rst
@@ -29,9 +29,9 @@ over the hardware, then build the simulation.
 
         // Get a description of the partition the model over the cores
         // (and gpu if available) on node.
-        auto decomp = arb::partition_load_balance(recipe, node);
+        arb::domain_decomposition decomp = arb::partition_load_balance(recipe, node);
 
-        // Instatitate the simulation that will run on the hardware described by node.
+        // Instatitate the simulation.
         arb::simulation sim(recipe, decomp);
 
 
@@ -43,14 +43,14 @@ Class Documentation
 .. cpp:class:: simulation
 
     The executable form of a model. A simulation is constructed
-    from a recipe, and then used to update model state and measure model state.
+    from a recipe, and then used to update and monitor model state.
 
     Simulations take the following inputs:
 
-        * The **constructor** takes an :cpp:class:`arb::recipe` that describes the model.
-        * The **constructor** takes an :cpp:class:`arb::domain_decomposition` that
-          describes how the cells in the model assigned to hardware resources.
-        * **Experimental inputs** that could change between model runs, such
+        * The **constructor** takes an :cpp:class:`arb::recipe` that describes
+          the model, and an :cpp:class:`arb::domain_decomposition` that
+          describes how the cells in the model are assigned to hardware resources.
+        * **Experimental inputs** that can change between model runs, such
           as external spike trains.
 
     Simulations provide an interface for executing and interacting with the model:
@@ -125,14 +125,15 @@ Class Documentation
 
     .. cpp:function:: std::size_t num_spikes() const
 
-        The total number of spikes in the global model.
+        The total number of spikes that occurred since either construction or
+        last resetting the model.
 
     .. cpp:function:: void set_global_spike_callback(spike_export_function export_callback)
 
         Register a callback that will perform an export of the global spike vector.
+        Will be called on the MPI rank/domain with id 0.
 
     .. cpp:function:: void set_local_spike_callback(spike_export_function export_callback)
 
         Register a callback that will perform an export of the rank local spike vector.
-
-
+        Will be called on each MPI rank/domain with a copy of the local spikes.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -53,6 +53,8 @@ Some key features include:
    cpp_intro
    cpp_common
    cpp_recipe
+   cpp_domdec
+   cpp_simulation
 
 .. toctree::
    :caption: Developers:

--- a/doc/sampling_api.rst
+++ b/doc/sampling_api.rst
@@ -1,3 +1,5 @@
+.. _sampling_api:
+
 Sampling API
 ============
 

--- a/src/domain_decomposition.hpp
+++ b/src/domain_decomposition.hpp
@@ -47,11 +47,6 @@ struct group_description {
 /// A load balancing algorithm is responsible for generating the
 /// domain_decomposition, e.g. arb::partitioned_load_balancer().
 struct domain_decomposition {
-    /// Tests whether a gid is on the local domain.
-    bool is_local_gid(cell_gid_type gid) const {
-        return gid_domain(gid)==domain_id;
-    }
-
     /// Return the domain id of cell with gid.
     /// Supplied by the load balancing algorithm that generates the domain
     /// decomposition.

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -253,11 +253,11 @@ void simulation::set_binning_policy(binning_kind policy, time_type bin_interval)
 }
 
 void simulation::set_global_spike_callback(spike_export_function export_callback) {
-    global_export_callback_ = export_callback;
+    global_export_callback_ = std::move(export_callback);
 }
 
 void simulation::set_local_spike_callback(spike_export_function export_callback) {
-    local_export_callback_ = export_callback;
+    local_export_callback_ = std::move(export_callback);
 }
 
 util::optional<cell_size_type> simulation::local_cell_index(cell_gid_type gid) {

--- a/tests/global_communication/test_domain_decomposition.cpp
+++ b/tests/global_communication/test_domain_decomposition.cpp
@@ -88,10 +88,7 @@ TEST(domain_decomposition, homogeneous_population) {
         auto gids = util::make_span(b, e);
         for (auto gid: gids) {
             EXPECT_EQ(I, D.gid_domain(gid));
-            EXPECT_TRUE(D.is_local_gid(gid));
         }
-        EXPECT_FALSE(D.is_local_gid(b-1));
-        EXPECT_FALSE(D.is_local_gid(e));
 
         // Each cell group contains 1 cell of kind cable1d_neuron
         // Each group should also be tagged for cpu execution
@@ -122,10 +119,7 @@ TEST(domain_decomposition, homogeneous_population) {
         auto gids = util::make_span(b, e);
         for (auto gid: gids) {
             EXPECT_EQ(I, D.gid_domain(gid));
-            EXPECT_TRUE(D.is_local_gid(gid));
         }
-        EXPECT_FALSE(D.is_local_gid(b-1));
-        EXPECT_FALSE(D.is_local_gid(e));
 
         // Each cell group contains 1 cell of kind cable1d_neuron
         // Each group should also be tagged for cpu execution
@@ -165,10 +159,7 @@ TEST(domain_decomposition, heterogeneous_population) {
         auto gids = util::make_span(b, e);
         for (auto gid: gids) {
             EXPECT_EQ(I, D.gid_domain(gid));
-            EXPECT_TRUE(D.is_local_gid(gid));
         }
-        EXPECT_FALSE(D.is_local_gid(b-1));
-        EXPECT_FALSE(D.is_local_gid(e));
 
         // Each cell group contains 1 cell of kind cable1d_neuron
         // Each group should also be tagged for cpu execution

--- a/tests/unit/test_domain_decomposition.cpp
+++ b/tests/unit/test_domain_decomposition.cpp
@@ -61,9 +61,7 @@ TEST(domain_decomposition, homogenous_population)
         auto gids = util::make_span(0, num_cells);
         for (auto gid: gids) {
             EXPECT_EQ(0, D.gid_domain(gid));
-            EXPECT_TRUE(D.is_local_gid(gid));
         }
-        EXPECT_FALSE(D.is_local_gid(num_cells));
 
         // Each cell group contains 1 cell of kind cable1d_neuron
         // Each group should also be tagged for cpu execution
@@ -89,9 +87,7 @@ TEST(domain_decomposition, homogenous_population)
         auto gids = util::make_span(0, num_cells);
         for (auto gid: gids) {
             EXPECT_EQ(0, D.gid_domain(gid));
-            EXPECT_TRUE(D.is_local_gid(gid));
         }
-        EXPECT_FALSE(D.is_local_gid(num_cells));
 
         // Each cell group contains 1 cell of kind cable1d_neuron
         // Each group should also be tagged for cpu execution
@@ -124,9 +120,7 @@ TEST(domain_decomposition, heterogenous_population)
         auto gids = util::make_span(0, num_cells);
         for (auto gid: gids) {
             EXPECT_EQ(0, D.gid_domain(gid));
-            EXPECT_TRUE(D.is_local_gid(gid));
         }
-        EXPECT_FALSE(D.is_local_gid(num_cells));
 
         // Each cell group contains 1 cell of kind cable1d_neuron
         // Each group should also be tagged for cpu execution


### PR DESCRIPTION
Add two new documentation pages for the C++ API
  1. Domain decomposition page that covers `domain_decomposition`, `node_info` and `partition_load_balance`.
  2. Simulation page that describes `arb::simulation` API interface.

Also
  * fixed some small typos elsewhere in the docs.
  * use `std::move` when adding spike callbacks to `arb::simulation` (useful if callbacks are stateful).