### PR TITLE
fix small compilation errors on OSX

### DIFF
--- a/src/util/debug.hpp
+++ b/src/util/debug.hpp
@@ -7,7 +7,7 @@
 #include <utility>
 
 extern "C" {
-#include <endian.h>
+#include <sys/types.h>
 }
 
 #include <threading/threading.hpp>

--- a/src/util/debug.hpp
+++ b/src/util/debug.hpp
@@ -7,6 +7,8 @@
 #include <utility>
 
 extern "C" {
+// The system header endian.h is not in /sys/include/ on Mac OS X.
+// Include sys/types.h, which pulls in endian.h on all systems.
 #include <sys/types.h>
 }
 

--- a/tests/unit/test_padded.cpp
+++ b/tests/unit/test_padded.cpp
@@ -24,7 +24,7 @@ static bool is_aligned(void* p, std::size_t k) {
 
 TEST(padded_vector, alignment) {
     padded_allocator<double> pa(1024);
-    pvector<double> a(101, pa);
+    pvector<double> a(101, 0.0, pa);
 
     EXPECT_EQ(1024u, a.get_allocator().alignment());
     EXPECT_TRUE(is_aligned(a.data(), 1024));
@@ -34,14 +34,14 @@ TEST(padded_vector, allocator_constraints) {
     EXPECT_THROW(padded_allocator<char>(7), std::range_error);
 
     padded_allocator<char> pa(2); // less than sizeof(void*)
-    std::vector<char, padded_allocator<char>> v(7, pa);
+    std::vector<char, padded_allocator<char>> v(7, 'a', pa);
 
     EXPECT_TRUE(is_aligned(v.data(), sizeof(void*)));
 }
 
 TEST(padded_vector, allocator_propagation) {
     padded_allocator<double> pa(1024);
-    pvector<double> a(101, pa);
+    pvector<double> a(101, 0, pa);
 
     EXPECT_EQ(pa, a.get_allocator());
 


### PR DESCRIPTION
Fixes two small compilation errors on OSX:
  * fixes #481 : use `sys/types.h` to include `endian.h` on BSD;
  * fixes #480 : don't use a "since C++14" constructor for `std::vector` in unit tests.