### PR TITLE
Generic external variables for CUDA printer.

### DIFF
--- a/modcc/printer/cprinter.cpp
+++ b/modcc/printer/cprinter.cpp
@@ -412,11 +412,11 @@ void emit_api_body(std::ostream& out, APIMethod* method) {
 
 // SIMD printing:
 
-std::string index_i_name(const std::string& index_var) {
+static std::string index_i_name(const std::string& index_var) {
     return index_var+"i_";
 }
 
-std::string index_constraint_name(const std::string& index_var) {
+static std::string index_constraint_name(const std::string& index_var) {
     return index_var+"constraint_";
 }
 

--- a/src/memory/device_coordinator.hpp
+++ b/src/memory/device_coordinator.hpp
@@ -251,7 +251,7 @@ public:
     // fill memory
     void set(view_type &rng, value_type value) {
         if (rng.size()) {
-            gpu::fill<value_type>(rng.data(), value, rng.size());
+            arb::gpu::fill<value_type>(rng.data(), value, rng.size());
         }
     }
 


### PR DESCRIPTION
Replace hard-coded index variable names in modcc cuda printer with ones derived from the external variable, using `decode_indexed_variable`.