### PR TITLE
profile multicore mechanism state and current calls individually

### DIFF
--- a/modcc/printer/cprinter.cpp
+++ b/modcc/printer/cprinter.cpp
@@ -79,6 +79,7 @@ std::string emit_cpp_source(const Module& module_, const std::string& ns, simd_s
         "#include <cstddef>\n"
         "#include <memory>\n"
         "#include <" << arb_header_prefix() << "backends/multicore/mechanism.hpp>\n"
+        "#include <" << arb_header_prefix() << "profiling/profiler.hpp>\n"
         "#include <" << arb_header_prefix() << "math.hpp>\n";
 
     if (with_simd) {
@@ -280,11 +281,15 @@ std::string emit_cpp_source(const Module& module_, const std::string& ns, simd_s
     out << popindent << "}\n\n";
 
     out << "void " << class_name << "::nrn_state() {\n" << indent;
+    out << "PE(advance_integrate_state_" << name << ");\n";
     emit_body(state_api);
+    out <<  "PL();\n";
     out << popindent << "}\n\n";
 
     out << "void " << class_name << "::nrn_current() {\n" << indent;
+    out << "PE(advance_integrate_current_" << name << ");\n";
     emit_body(current_api);
+    out <<  "PL();\n";
     out << popindent << "}\n\n";
 
     out << "void " << class_name << "::write_ions() {\n" << indent;

--- a/src/fvm_lowered_cell_impl.hpp
+++ b/src/fvm_lowered_cell_impl.hpp
@@ -165,13 +165,13 @@ fvm_integration_result fvm_lowered_cell_impl<Backend>::integrate(
         state_->deliverable_events.mark_until_after(state_->time);
         PL();
 
-        PE(advance_integrate_current);
+        PE(advance_integrate_current_zero);
         state_->zero_currents();
+        PL();
         for (auto& m: mechanisms_) {
             m->deliver_events();
             m->nrn_current();
         }
-        PL();
 
         PE(advance_integrate_events);
         state_->deliverable_events.drop_marked_events();
@@ -203,11 +203,9 @@ fvm_integration_result fvm_lowered_cell_impl<Backend>::integrate(
 
         // Integrate mechanism state.
 
-        PE(advance_integrate_state);
         for (auto& m: mechanisms_) {
             m->nrn_state();
         }
-        PL();
 
         // Update ion concentrations.
 


### PR DESCRIPTION
The built in profiler generates timings for state and current for individual multicore mechanisms.

Modcc generates and `PE(advance_integrate_{state,current}_X)` profiler calls (along with corresponding `PL()` for calls to multicore mechanism `nrn_state` and `nrn_current` API calls.

No timings are made for the gpu back end, which is not properly supported by the current  profiling tools.