### PR TITLE
Simd partition by constraint

### DIFF
--- a/modcc/printer/cprinter.cpp
+++ b/modcc/printer/cprinter.cpp
@@ -33,12 +33,29 @@ struct cprint {
 
 struct simdprint {
     Expression* expr_;
-    bool is_indexed_;
-    explicit simdprint(Expression* expr): expr_(expr), is_indexed_(false) {}
-    explicit simdprint(Expression* expr, bool is_indexed): expr_(expr), is_indexed_(is_indexed) {}
+    bool is_var_indexed_;
+    bool is_contiguous;
+    bool is_constant;
+
+    explicit simdprint(Expression* expr): expr_(expr), is_var_indexed_(false), is_contiguous(false), is_constant(false) {}
+    explicit simdprint(Expression* expr, bool is_indexed):
+            expr_(expr), is_var_indexed_(is_indexed) {}
+
+    void set_var_indexed() {
+        is_var_indexed_ = true;
+    }
+    void set_contiguous() {
+        is_contiguous = true;
+    }
+    void set_constant() {
+        is_constant = true;
+    }
 
     friend std::ostream& operator<<(std::ostream& out, const simdprint& w) {
-        SimdPrinter printer(out, w.is_indexed_);
+        SimdPrinter printer(out);
+        printer.set_var_indexed_to(w.is_var_indexed_);
+        printer.set_contiguous_to(w.is_contiguous);
+        printer.set_constant_to(w.is_constant);
         return w.expr_->accept(&printer), out;
     }
 };
@@ -378,7 +395,7 @@ void emit_state_read(std::ostream& out, LocalVariable* local) {
     out << "value_type " << cprint(local) << " = ";
 
     if (local->is_read()) {
-        out << cprint(local->external_variable()) << ";\n";
+         out << cprint(local->external_variable()) << ";\n";
     }
     else {
         out << "0;\n";
@@ -388,7 +405,7 @@ void emit_state_read(std::ostream& out, LocalVariable* local) {
 void emit_state_update(std::ostream& out, Symbol* from, IndexedVariable* external) {
     if (!external->is_write()) return;
 
-    const char* op = external->op()==tok::plus? " += ": " -= ";
+    const char *op = external->op() == tok::plus ? " += " : " -= ";
     out << cprint(external) << op << from->name() << ";\n";
 }
 
@@ -420,7 +437,7 @@ static std::string index_i_name(const std::string& index_var) {
 }
 
 static std::string index_constraint_name(const std::string& index_var) {
-    return index_var+"category_";
+    return index_var+"constraint_";
 }
 
 
@@ -433,7 +450,7 @@ void SimdPrinter::visit(LocalVariable* sym) {
 }
 
 void SimdPrinter::visit(VariableExpression *sym) {
-    if(is_indexed_) {
+    if(is_var_indexed_) {
         out_ << "simd_value(" << sym->name() << "+index_)";
     }
     else if (sym->is_range()) {
@@ -455,7 +472,7 @@ void SimdPrinter::visit(AssignmentExpression* e) {
     if (lhs->is_variable() && lhs->is_variable()->is_range()) {
         out_ << "simd_value(";
         e->rhs()->accept(this);
-        if(is_indexed_)
+        if(is_var_indexed_)
             out_ << ").copy_to(" << lhs->name() << "+index_)";
         else
             out_ << ").copy_to(" << lhs->name() << "+i_)";
@@ -468,9 +485,21 @@ void SimdPrinter::visit(AssignmentExpression* e) {
 
 void SimdPrinter::visit(IndexedVariable *sym) {
     indexed_variable_info v = decode_indexed_variable(sym);
-    out_ << "S::indirect(" << v.data_var
-         << ", " << index_i_name(v.index_var)
-         << ", constraint_category_)";
+    if(is_contiguous_) {
+        out_ << v.data_var
+             << " + " << v.index_var
+             << "[index_]";
+    }
+    else if(is_constant_){
+        out_ << v.data_var
+             << "[" << v.index_var
+             << "element0]";
+    }
+    else {
+        out_ << "S::indirect(" << v.data_var
+             << ", " << index_i_name(v.index_var)
+             << ", constraint_category_)";
+    }
 }
 
 void SimdPrinter::visit(CallExpression* e) {
@@ -515,22 +544,35 @@ void emit_simd_procedure_proto(std::ostream& out, ProcedureExpression* e, const 
     out << ")";
 }
 
-void emit_simd_state_read(std::ostream& out, LocalVariable* local) {
+void emit_simd_state_read(std::ostream& out, LocalVariable* local, simdprint& printer) {
     out << "simd_value " << local->name();
 
     if (local->is_read()) {
-        out << "(" << simdprint(local->external_variable()) << ");\n";
+        if(printer.is_constant) {
+            out << " = " << printer << ";\n";
+        }
+        else {
+            out << "(" << printer << ");\n";
+        }
     }
     else {
         out << " = 0;\n";
     }
 }
 
-void emit_simd_state_update(std::ostream& out, Symbol* from, IndexedVariable* external) {
+void emit_simd_state_update(std::ostream& out, Symbol* from, IndexedVariable* external, simdprint &printer) {
     if (!external->is_write()) return;
 
-    const char* op = external->op()==tok::plus? " += ": " -= ";
-    out << simdprint(external) << op << from->name() << ";\n";
+    const char *op = external->op() == tok::plus ? " += " : " -= ";
+    if(printer.is_contiguous) {
+        out << "simd_value t_"<< external->name() <<"(" << printer <<");\n";
+        out << "t_" << external->name() << op << from->name() << ";\n";
+        out << "t_" << external->name() << ".copy_to(" << printer << ");\n";
+
+    }
+    else {
+        out << printer << op << from->name() << ";\n";
+    }
 }
 
 
@@ -568,18 +610,21 @@ void emit_simd_api_body(std::ostream& out, APIMethod* method, moduleKind module_
 
                 out << "unsigned index_ = constraint_indices_.contiguous_indices[i_];\n";
 
-                for (auto &index: indices) {
-                    out << index_i_name(index) << ".copy_from(" << index << ".data() + index_);\n";
+                for (auto &sym: indexed_vars) {
+                    simdprint printer(sym->external_variable());
+                    printer.set_contiguous();
+                    emit_simd_state_read(out, sym, printer);
                 }
 
-                for (auto &sym: indexed_vars) {
-                    emit_simd_state_read(out, sym);
-                }
+                simdprint printer(body);
+                printer.set_var_indexed();
 
-                out << simdprint(body,true);
+                out << printer;
 
                 for (auto &sym: indexed_vars) {
-                    emit_simd_state_update(out, sym, sym->external_variable());
+                    simdprint printer(sym->external_variable());
+                    printer.set_contiguous();
+                    emit_simd_state_update(out, sym, sym->external_variable(), printer);
                 }
                 out << popindent << "}\n";
             }
@@ -597,13 +642,18 @@ void emit_simd_api_body(std::ostream& out, APIMethod* method, moduleKind module_
                 }
 
                 for (auto &sym: indexed_vars) {
-                    emit_simd_state_read(out, sym);
+                    simdprint printer(sym->external_variable());
+                    emit_simd_state_read(out, sym, printer);
                 }
 
-                out << simdprint(body,true);
+                simdprint printer(body);
+                printer.set_var_indexed();
+
+                out << printer;
 
                 for (auto &sym: indexed_vars) {
-                    emit_simd_state_update(out, sym, sym->external_variable());
+                    simdprint printer(sym->external_variable());
+                    emit_simd_state_update(out, sym, sym->external_variable(), printer);
                 }
                 out << popindent << "}\n";
             }
@@ -621,13 +671,19 @@ void emit_simd_api_body(std::ostream& out, APIMethod* method, moduleKind module_
                 }
 
                 for (auto &sym: indexed_vars) {
-                    emit_simd_state_read(out, sym);
+                    simdprint printer(sym->external_variable());
+                    emit_simd_state_read(out, sym, printer);
+
                 }
 
-                out << simdprint(body,true);
+                simdprint printer(body);
+                printer.set_var_indexed();
+
+                out << printer;
 
                 for (auto &sym: indexed_vars) {
-                    emit_simd_state_update(out, sym, sym->external_variable());
+                    simdprint printer(sym->external_variable());
+                    emit_simd_state_update(out, sym, sym->external_variable(), printer);
                 }
                 out << popindent << "}\n";
             }
@@ -642,17 +698,24 @@ void emit_simd_api_body(std::ostream& out, APIMethod* method, moduleKind module_
 
 
                 for (auto &index: indices) {
-                    out << index_i_name(index) << ".copy_from(" << index << ".data() + index_);\n";
+                    out << "simd_index::scalar_type " << index <<"element0 = " << index <<"[index_];\n";
+                    out << index_i_name(index) << " = " << index << "element0;\n";
                 }
 
                 for (auto &sym: indexed_vars) {
-                    emit_simd_state_read(out, sym);
+                    simdprint printer(sym->external_variable());
+                    printer.set_constant();
+                    emit_simd_state_read(out, sym, printer);
                 }
 
-                out << simdprint(body,true);
+                simdprint printer(body);
+                printer.set_var_indexed();
+
+                out << printer;
 
                 for (auto &sym: indexed_vars) {
-                    emit_simd_state_update(out, sym, sym->external_variable());
+                    simdprint printer(sym->external_variable());
+                    emit_simd_state_update(out, sym, sym->external_variable(), printer);
                 }
                 out << popindent << "}\n";
             }
@@ -667,13 +730,15 @@ void emit_simd_api_body(std::ostream& out, APIMethod* method, moduleKind module_
             }
 
             for (auto &sym: indexed_vars) {
-                emit_simd_state_read(out, sym);
+                simdprint printer(sym->external_variable());
+                emit_simd_state_read(out, sym, printer);
             }
 
             out << simdprint(body);
 
             for (auto &sym: indexed_vars) {
-                emit_simd_state_update(out, sym, sym->external_variable());
+                simdprint printer(sym->external_variable());
+                emit_simd_state_update(out, sym, sym->external_variable(), printer);
             }
             out << popindent << "}\n";
         }

--- a/modcc/printer/cprinter.cpp
+++ b/modcc/printer/cprinter.cpp
@@ -58,14 +58,10 @@ struct simdprint {
     void set_indirect_index() {
         is_indirect_index_ = true;
     }
-    void set_constraint(simd_expr_constraint constraint) {
-        constraint_ = constraint;
-    }
 
     friend std::ostream& operator<<(std::ostream& out, const simdprint& w) {
         SimdPrinter printer(out);
         printer.set_var_indexed_to(w.is_indirect_index_);
-        printer.set_constraint(w.constraint_);
         return w.expr_->accept(&printer), out;
     }
 };

--- a/modcc/printer/cprinter.hpp
+++ b/modcc/printer/cprinter.hpp
@@ -41,6 +41,7 @@ protected:
 class SimdPrinter: public Visitor {
 public:
     SimdPrinter(std::ostream& out): out_(out) {}
+    SimdPrinter(std::ostream& out, bool is_indexed): out_(out), is_indexed_(is_indexed) {}
 
     void visit(Expression* e) override {
         throw compiler_exception("SimdPrinter cannot translate expression "+e->to_string());
@@ -60,4 +61,5 @@ public:
 
 private:
     std::ostream& out_;
+    bool is_indexed_;
 };

--- a/modcc/printer/cprinter.hpp
+++ b/modcc/printer/cprinter.hpp
@@ -41,10 +41,18 @@ protected:
 class SimdPrinter: public Visitor {
 public:
     SimdPrinter(std::ostream& out): out_(out) {}
-    SimdPrinter(std::ostream& out, bool is_indexed): out_(out), is_indexed_(is_indexed) {}
 
     void visit(Expression* e) override {
         throw compiler_exception("SimdPrinter cannot translate expression "+e->to_string());
+    }
+    void set_var_indexed_to(bool is_var_indexed) {
+        is_var_indexed_ = is_var_indexed;
+    }
+    void set_contiguous_to(bool is_contiguous) {
+        is_contiguous_ = is_contiguous;
+    }
+    void set_constant_to(bool is_constant) {
+        is_constant_ = is_constant;
     }
 
     void visit(BlockExpression*) override;
@@ -61,5 +69,7 @@ public:
 
 private:
     std::ostream& out_;
-    bool is_indexed_;
+    bool is_var_indexed_;
+    bool is_contiguous_;
+    bool is_constant_;
 };

--- a/modcc/printer/cprinter.hpp
+++ b/modcc/printer/cprinter.hpp
@@ -38,6 +38,13 @@ protected:
     std::ostream& out_;
 };
 
+
+enum class simd_expr_constraint{
+    constant,
+    contiguous,
+    other
+};
+
 class SimdPrinter: public Visitor {
 public:
     SimdPrinter(std::ostream& out): out_(out) {}
@@ -45,14 +52,11 @@ public:
     void visit(Expression* e) override {
         throw compiler_exception("SimdPrinter cannot translate expression "+e->to_string());
     }
-    void set_var_indexed_to(bool is_var_indexed) {
-        is_var_indexed_ = is_var_indexed;
+    void set_var_indexed_to(bool is_indirect_index) {
+        is_indirect_index_ = is_indirect_index;
     }
-    void set_contiguous_to(bool is_contiguous) {
-        is_contiguous_ = is_contiguous;
-    }
-    void set_constant_to(bool is_constant) {
-        is_constant_ = is_constant;
+    void set_constraint(simd_expr_constraint constraint) {
+        constraint_ = constraint;
     }
 
     void visit(BlockExpression*) override;
@@ -69,7 +73,6 @@ public:
 
 private:
     std::ostream& out_;
-    bool is_var_indexed_;
-    bool is_contiguous_;
-    bool is_constant_;
+    bool is_indirect_index_;
+    simd_expr_constraint constraint_;
 };

--- a/modcc/printer/cprinter.hpp
+++ b/modcc/printer/cprinter.hpp
@@ -55,9 +55,6 @@ public:
     void set_var_indexed_to(bool is_indirect_index) {
         is_indirect_index_ = is_indirect_index;
     }
-    void set_constraint(simd_expr_constraint constraint) {
-        constraint_ = constraint;
-    }
 
     void visit(BlockExpression*) override;
     void visit(CallExpression*) override;
@@ -74,5 +71,4 @@ public:
 private:
     std::ostream& out_;
     bool is_indirect_index_;
-    simd_expr_constraint constraint_;
 };

--- a/src/backends/multicore/mechanism.cpp
+++ b/src/backends/multicore/mechanism.cpp
@@ -19,6 +19,7 @@
 #include <backends/multicore/mechanism.hpp>
 #include <backends/multicore/multicore_common.hpp>
 #include <backends/multicore/fvm.hpp>
+#include <backends/multicore/partition_by_constraint.hpp>
 
 namespace arb {
 namespace multicore {
@@ -127,6 +128,7 @@ void mechanism::instantiate(fvm_size_type id, backend::shared_state& shared, con
     node_index_ = iarray(width_padded_, pad);
     copy_extend(pos_data.cv, node_index_, pos_data.cv.back());
     copy_extend(pos_data.weight, make_range(data_.data(), data_.data()+width_padded_), 0);
+    gen_constraint(node_index_, constraint_index_);
 
     for (auto i: ion_index_table()) {
         util::optional<ion_state&> oion = value_by_key(shared.ion_data, i.first);

--- a/src/backends/multicore/mechanism.cpp
+++ b/src/backends/multicore/mechanism.cpp
@@ -128,7 +128,7 @@ void mechanism::instantiate(fvm_size_type id, backend::shared_state& shared, con
     node_index_ = iarray(width_padded_, pad);
     copy_extend(pos_data.cv, node_index_, pos_data.cv.back());
     copy_extend(pos_data.weight, make_range(data_.data(), data_.data()+width_padded_), 0);
-    gen_constraint(node_index_, constraint_indices_, width_);
+    generate_index_constraint_partitions(node_index_, index_constraints_, width_);
 
     for (auto i: ion_index_table()) {
         util::optional<ion_state&> oion = value_by_key(shared.ion_data, i.first);
@@ -143,7 +143,7 @@ void mechanism::instantiate(fvm_size_type id, backend::shared_state& shared, con
         ion_index = iarray(width_padded_, pad);
         copy_extend(indices, ion_index, util::back(indices));
 
-        if(!compatible_constraint_indices(node_index_, ion_index))
+        if(!compatible_index_constraints(node_index_, ion_index))
             throw std::runtime_error("ion_index and node_index not compatible");
     }
 

--- a/src/backends/multicore/mechanism.cpp
+++ b/src/backends/multicore/mechanism.cpp
@@ -128,7 +128,7 @@ void mechanism::instantiate(fvm_size_type id, backend::shared_state& shared, con
     node_index_ = iarray(width_padded_, pad);
     copy_extend(pos_data.cv, node_index_, pos_data.cv.back());
     copy_extend(pos_data.weight, make_range(data_.data(), data_.data()+width_padded_), 0);
-    gen_constraint(node_index_, constraint_index_);
+    gen_constraint(node_index_, constraint_indices_, width_);
 
     for (auto i: ion_index_table()) {
         util::optional<ion_state&> oion = value_by_key(shared.ion_data, i.first);
@@ -142,6 +142,9 @@ void mechanism::instantiate(fvm_size_type id, backend::shared_state& shared, con
         auto& ion_index = *i.second;
         ion_index = iarray(width_padded_, pad);
         copy_extend(indices, ion_index, util::back(indices));
+
+        if(!compatible_constraint_indices(node_index_, ion_index))
+            throw std::runtime_error("ion_index and node_index not compatible");
     }
 
 }

--- a/src/backends/multicore/mechanism.hpp
+++ b/src/backends/multicore/mechanism.hpp
@@ -82,7 +82,7 @@ protected:
     // Per-mechanism index and weight data, excepting ion indices.
 
     iarray node_index_;
-    constraint_partition constraint_index_;
+    constraint_partitions constraint_indices_;
     const value_type* weight_;    // Points within data_ after instantiation.
 
     // Bulk storage for state and parameter variables.

--- a/src/backends/multicore/mechanism.hpp
+++ b/src/backends/multicore/mechanism.hpp
@@ -12,6 +12,7 @@
 #include <mechanism.hpp>
 
 #include <backends/multicore/multicore_common.hpp>
+#include <backends/multicore/partition_by_constraint.hpp>
 #include <backends/multicore/fvm.hpp>
 
 namespace arb {
@@ -81,6 +82,7 @@ protected:
     // Per-mechanism index and weight data, excepting ion indices.
 
     iarray node_index_;
+    constraint_partition constraint_index_;
     const value_type* weight_;    // Points within data_ after instantiation.
 
     // Bulk storage for state and parameter variables.

--- a/src/backends/multicore/mechanism.hpp
+++ b/src/backends/multicore/mechanism.hpp
@@ -82,7 +82,7 @@ protected:
     // Per-mechanism index and weight data, excepting ion indices.
 
     iarray node_index_;
-    constraint_partitions constraint_indices_;
+    constraint_partitions index_constraints_;
     const value_type* weight_;    // Points within data_ after instantiation.
 
     // Bulk storage for state and parameter variables.

--- a/src/backends/multicore/mechanism.hpp
+++ b/src/backends/multicore/mechanism.hpp
@@ -82,7 +82,7 @@ protected:
     // Per-mechanism index and weight data, excepting ion indices.
 
     iarray node_index_;
-    constraint_partitions index_constraints_;
+    constraint_partition index_constraints_;
     const value_type* weight_;    // Points within data_ after instantiation.
 
     // Bulk storage for state and parameter variables.

--- a/src/backends/multicore/partition_by_constraint.hpp
+++ b/src/backends/multicore/partition_by_constraint.hpp
@@ -1,0 +1,109 @@
+#pragma once
+
+#include<vector>
+#include<simd/simd.hpp>
+
+namespace arb {
+namespace multicore {
+    
+namespace S = ::arb::simd;
+static constexpr unsigned simd_width_ = S::simd_abi::native_width<fvm_value_type>::value;
+
+   struct constraint_partition {
+
+       using iarray = arb::multicore::iarray;
+
+       static constexpr int num_compartments = 4;
+       iarray full_index_compartments;
+       std::vector<int> compartment_sizes;
+   };
+
+
+   template <typename T>
+   void gen_constraint(const T& node_index, constraint_partition& partitioned_index) {
+       using iarray = arb::multicore::iarray;
+
+       iarray serial_part;
+       iarray independent_part;
+       iarray contiguous_part;
+       iarray constant_part;
+
+       for (unsigned i = 0; i < node_index.size(); i+= simd_width_) {
+           index_constraint con = index_constraint::contiguous;
+           if(simd_width_ != 1) {
+               if(node_index[i] == node_index[i + 1])
+                   con = index_constraint::constant;
+               for (unsigned j = i + 1; j < i + simd_width_; j++) {
+                   switch (con) {
+                       case index_constraint::independent: {
+                           if (node_index[j] == node_index[j - 1])
+                               con = index_constraint::none;
+                       }
+                           break;
+                       case index_constraint::constant: {
+                           if (node_index[j] != node_index[j - 1])
+                               con = index_constraint::none;
+                       }
+                           break;
+                       case index_constraint::contiguous: {
+                           if (node_index[j] != node_index[j - 1] + 1)
+                               con = index_constraint::independent;
+                       }
+                           break;
+                       default: {
+                       }
+                   }
+               }
+           }
+           switch(con) {
+               case index_constraint::none: {
+                   for (unsigned j = 0; j < simd_width_; j++)
+                       serial_part.push_back(node_index[i + j]);
+               }
+               break;
+               case index_constraint::independent: {
+                   for (unsigned j = 0; j < simd_width_; j++)
+                       independent_part.push_back(node_index[i + j]);
+               }
+               break;
+               case index_constraint::constant: {
+                   for (unsigned j = 0; j < simd_width_; j++)
+                       constant_part.push_back(node_index[i + j]);
+               }
+               break;
+               case index_constraint::contiguous: {
+                   for (unsigned j = 0; j < simd_width_; j++)
+                       contiguous_part.push_back(node_index[i + j]);
+               }
+               break;
+           }
+       }
+
+       partitioned_index.full_index_compartments.reserve(
+               serial_part.size() + independent_part.size() +
+               contiguous_part.size() + constant_part.size() );// preallocate memory
+
+       partitioned_index.full_index_compartments.insert(
+               partitioned_index.full_index_compartments.end(),
+               contiguous_part.begin(), contiguous_part.end() );
+       partitioned_index.full_index_compartments.insert(
+               partitioned_index.full_index_compartments.end(),
+               independent_part.begin(), independent_part.end() );
+       partitioned_index.full_index_compartments.insert(
+               partitioned_index.full_index_compartments.end(),
+               serial_part.begin(), serial_part.end() );
+       partitioned_index.full_index_compartments.insert(
+               partitioned_index.full_index_compartments.end(),
+               constant_part.begin(), constant_part.end() );
+
+       partitioned_index.compartment_sizes.push_back(contiguous_part.size());
+       partitioned_index.compartment_sizes.push_back(independent_part.size());
+       partitioned_index.compartment_sizes.push_back(serial_part.size());
+       partitioned_index.compartment_sizes.push_back(constant_part.size());
+   }
+
+} // namespace util
+} // namespace arb
+
+
+

--- a/src/backends/multicore/partition_by_constraint.hpp
+++ b/src/backends/multicore/partition_by_constraint.hpp
@@ -5,117 +5,117 @@
 
 namespace arb {
 namespace multicore {
-    
+
 namespace S = ::arb::simd;
 static constexpr unsigned simd_width_ = S::simd_abi::native_width<fvm_value_type>::value;
 
-    struct constraint_partitions {
-        using iarray = arb::multicore::iarray;
+struct constraint_partitions {
+    using iarray = arb::multicore::iarray;
 
-        static constexpr int num_compartments = 4;
-        iarray contiguous_indices;
-        iarray constant_indices;
-        iarray independent_indices;
-        iarray serialized_indices;
-        int size;
-        //std::vector<int> compartment_sizes;
-        //std::vector<int> compartment_starts_and_ends;
-    };
+    static constexpr int num_compartments = 4;
+    iarray contiguous;
+    iarray constant;
+    iarray independent;
+    iarray none;
+};
 
+template <typename T>
+bool is_contiguous(const T& node_index, unsigned i) {
+    for (unsigned j = i + 1; j < i + simd_width_; j++) {
+        if(node_index[j] != node_index[j - 1] + 1)
+            return false;
+    }
+    return true;
+}
 
-    template <typename T>
-    index_constraint get_subvector_index_constraint(const T& node_index, unsigned i) {
-        index_constraint con = index_constraint::contiguous;
-        if(simd_width_ != 1) {
-            if(node_index[i] == node_index[i + 1])
-                con = index_constraint::constant;
-            for (unsigned j = i + 1; j < i + simd_width_; j++) {
-                switch (con) {
-                    case index_constraint::independent: {
-                        if (node_index[j] == node_index[j - 1])
-                            con = index_constraint::none;
-                    }
-                    break;
-                    case index_constraint::constant: {
-                        if (node_index[j] != node_index[j - 1])
-                            con = index_constraint::none;
-                    }
-                    break;
-                    case index_constraint::contiguous: {
-                        if (node_index[j] != node_index[j - 1] + 1) {
-                            con = index_constraint::independent;
-                            if(node_index[j] == node_index[j - 1])
-                                con = index_constraint::none;
-                        }
-                    }
-                    break;
-                    default: {
-                    }
-                }
+template <typename T>
+bool is_constant(const T& node_index, unsigned i) {
+    for (unsigned j = i + 1; j < i + simd_width_; j++) {
+        if(node_index[j] != node_index[j - 1])
+            return false;
+    }
+    return true;
+}
+
+template <typename T>
+bool is_independent(const T& node_index, unsigned i) {
+    for (unsigned j = i + 1; j < i + simd_width_; j++) {
+        if(node_index[j] == node_index[j - 1])
+            return false;
+    }
+    return true;
+}
+
+template <typename T>
+index_constraint get_subvector_index_constraint(const T& node_index, unsigned i) {
+
+    if (is_contiguous(node_index, i))
+        return index_constraint::contiguous;
+
+    else if (is_constant(node_index, i))
+        return index_constraint::constant;
+
+    else if (is_independent(node_index, i))
+        return index_constraint::independent;
+
+    else
+        return index_constraint::none;
+}
+
+template <typename T>
+void generate_index_constraint_partitions(const T& node_index, constraint_partitions& partitions, unsigned width) {
+
+    for (unsigned i = 0; i < node_index.size(); i+= simd_width_) {
+        index_constraint constraint = get_subvector_index_constraint(node_index, i);
+        switch(constraint) {
+            case index_constraint::none: {
+                partitions.none.push_back(i);
             }
+            break;
+            case index_constraint::independent: {
+                partitions.independent.push_back(i);
+            }
+            break;
+            case index_constraint::constant: {
+                partitions.constant.push_back(i);
+            }
+            break;
+            case index_constraint::contiguous: {
+                partitions.contiguous.push_back(i);
+            }
+            break;
         }
-        return con;
     }
 
-    template <typename T>
-    void gen_constraint(const T& node_index, constraint_partitions& partitioned_indices, unsigned width) {
+    if(simd_width_ != 1) {
+        unsigned size_of_constant_section = ((width + (simd_width_ - 1))/ simd_width_) -
+                                            (partitions.none.size() +
+                                             partitions.independent.size() +
+                                             partitions.contiguous.size() );
 
-        for (unsigned i = 0; i < node_index.size(); i+= simd_width_) {
-            index_constraint con = get_subvector_index_constraint(node_index, i);
-            switch(con) {
-                case index_constraint::none: {
-                    partitioned_indices.serialized_indices.push_back(i);
-                }
-                break;
-                case index_constraint::independent: {
-                    partitioned_indices.independent_indices.push_back(i);
-                }
-                break;
-                case index_constraint::constant: {
-                    partitioned_indices.constant_indices.push_back(i);
-                }
-                break;
-                case index_constraint::contiguous: {
-                    partitioned_indices.contiguous_indices.push_back(i);
-                }
-                break;
+        partitions.constant.resize(size_of_constant_section);
+    }
+    else {
+        partitions.contiguous.resize(width);
+    }
+
+}
+
+template <typename T>
+bool compatible_index_constraints(const T& node_index, const T& ion_index){
+    for (unsigned i = 0; i < node_index.size(); i+= simd_width_) {
+        index_constraint node_constraint = get_subvector_index_constraint(node_index, i);
+        index_constraint ion_constraint = get_subvector_index_constraint(ion_index, i);
+        if(node_constraint != ion_constraint) {
+            if(!((node_constraint == index_constraint::none) ||
+               (node_constraint == index_constraint::independent &&
+                ion_constraint == index_constraint::contiguous))) {
+                return false;
             }
         }
- 
-        if(simd_width_ != 1) {
-            unsigned size_of_constant_section = ((width + (simd_width_ - 1))/ simd_width_) -
-                                                (partitioned_indices.serialized_indices.size() +
-                                                 partitioned_indices.independent_indices.size() +
-                                                 partitioned_indices.contiguous_indices.size() );
- 
-            partitioned_indices.constant_indices.resize(size_of_constant_section);
-        }
-        else {
-            partitioned_indices.contiguous_indices.resize(width);
-        }
- 
-        partitioned_indices.size = node_index.size();
- 
     }
-  
-    template <typename T>
-    bool compatible_constraint_indices(const T& node_index, const T& ion_index){
-        for (unsigned i = 0; i < node_index.size(); i+= simd_width_) {
-            index_constraint node_constraint = get_subvector_index_constraint(node_index, i);
-            index_constraint ion_constraint = get_subvector_index_constraint(ion_index, i);
-            if(node_constraint != ion_constraint) {
-                if(!((node_constraint == index_constraint::none) ||
-                   (node_constraint == index_constraint::independent &&
-                    ion_constraint == index_constraint::contiguous))) {
-                    std::cout << static_cast<std::underlying_type<index_constraint>::type>(node_constraint)<<std::endl;
-                    std::cout << static_cast<std::underlying_type<index_constraint>::type>(ion_constraint)<<std::endl;
-                    return false;
-                }
-            }
- 
-        }
-        return true;
-    }
+    return true;
+}
 
 } // namespace util
 } // namespace arb

--- a/src/backends/multicore/partition_by_constraint.hpp
+++ b/src/backends/multicore/partition_by_constraint.hpp
@@ -9,98 +9,113 @@ namespace multicore {
 namespace S = ::arb::simd;
 static constexpr unsigned simd_width_ = S::simd_abi::native_width<fvm_value_type>::value;
 
-   struct constraint_partition {
+    struct constraint_partitions {
+        using iarray = arb::multicore::iarray;
 
-       using iarray = arb::multicore::iarray;
+        static constexpr int num_compartments = 4;
+        iarray contiguous_indices;
+        iarray constant_indices;
+        iarray independent_indices;
+        iarray serialized_indices;
+        int size;
+        //std::vector<int> compartment_sizes;
+        //std::vector<int> compartment_starts_and_ends;
+    };
 
-       static constexpr int num_compartments = 4;
-       iarray full_index_compartments;
-       std::vector<int> compartment_sizes;
-   };
 
+    template <typename T>
+    index_constraint get_subvector_index_constraint(const T& node_index, unsigned i) {
+        index_constraint con = index_constraint::contiguous;
+        if(simd_width_ != 1) {
+            if(node_index[i] == node_index[i + 1])
+                con = index_constraint::constant;
+            for (unsigned j = i + 1; j < i + simd_width_; j++) {
+                switch (con) {
+                    case index_constraint::independent: {
+                        if (node_index[j] == node_index[j - 1])
+                            con = index_constraint::none;
+                    }
+                    break;
+                    case index_constraint::constant: {
+                        if (node_index[j] != node_index[j - 1])
+                            con = index_constraint::none;
+                    }
+                    break;
+                    case index_constraint::contiguous: {
+                        if (node_index[j] != node_index[j - 1] + 1) {
+                            con = index_constraint::independent;
+                            if(node_index[j] == node_index[j - 1])
+                                con = index_constraint::none;
+                        }
+                    }
+                    break;
+                    default: {
+                    }
+                }
+            }
+        }
+        return con;
+    }
 
-   template <typename T>
-   void gen_constraint(const T& node_index, constraint_partition& partitioned_index) {
-       using iarray = arb::multicore::iarray;
+    template <typename T>
+    void gen_constraint(const T& node_index, constraint_partitions& partitioned_indices, unsigned width) {
 
-       iarray serial_part;
-       iarray independent_part;
-       iarray contiguous_part;
-       iarray constant_part;
-
-       for (unsigned i = 0; i < node_index.size(); i+= simd_width_) {
-           index_constraint con = index_constraint::contiguous;
-           if(simd_width_ != 1) {
-               if(node_index[i] == node_index[i + 1])
-                   con = index_constraint::constant;
-               for (unsigned j = i + 1; j < i + simd_width_; j++) {
-                   switch (con) {
-                       case index_constraint::independent: {
-                           if (node_index[j] == node_index[j - 1])
-                               con = index_constraint::none;
-                       }
-                           break;
-                       case index_constraint::constant: {
-                           if (node_index[j] != node_index[j - 1])
-                               con = index_constraint::none;
-                       }
-                           break;
-                       case index_constraint::contiguous: {
-                           if (node_index[j] != node_index[j - 1] + 1)
-                               con = index_constraint::independent;
-                       }
-                           break;
-                       default: {
-                       }
-                   }
-               }
-           }
-           switch(con) {
-               case index_constraint::none: {
-                   for (unsigned j = 0; j < simd_width_; j++)
-                       serial_part.push_back(node_index[i + j]);
-               }
-               break;
-               case index_constraint::independent: {
-                   for (unsigned j = 0; j < simd_width_; j++)
-                       independent_part.push_back(node_index[i + j]);
-               }
-               break;
-               case index_constraint::constant: {
-                   for (unsigned j = 0; j < simd_width_; j++)
-                       constant_part.push_back(node_index[i + j]);
-               }
-               break;
-               case index_constraint::contiguous: {
-                   for (unsigned j = 0; j < simd_width_; j++)
-                       contiguous_part.push_back(node_index[i + j]);
-               }
-               break;
-           }
-       }
-
-       partitioned_index.full_index_compartments.reserve(
-               serial_part.size() + independent_part.size() +
-               contiguous_part.size() + constant_part.size() );// preallocate memory
-
-       partitioned_index.full_index_compartments.insert(
-               partitioned_index.full_index_compartments.end(),
-               contiguous_part.begin(), contiguous_part.end() );
-       partitioned_index.full_index_compartments.insert(
-               partitioned_index.full_index_compartments.end(),
-               independent_part.begin(), independent_part.end() );
-       partitioned_index.full_index_compartments.insert(
-               partitioned_index.full_index_compartments.end(),
-               serial_part.begin(), serial_part.end() );
-       partitioned_index.full_index_compartments.insert(
-               partitioned_index.full_index_compartments.end(),
-               constant_part.begin(), constant_part.end() );
-
-       partitioned_index.compartment_sizes.push_back(contiguous_part.size());
-       partitioned_index.compartment_sizes.push_back(independent_part.size());
-       partitioned_index.compartment_sizes.push_back(serial_part.size());
-       partitioned_index.compartment_sizes.push_back(constant_part.size());
-   }
+        for (unsigned i = 0; i < node_index.size(); i+= simd_width_) {
+            index_constraint con = get_subvector_index_constraint(node_index, i);
+            switch(con) {
+                case index_constraint::none: {
+                    partitioned_indices.serialized_indices.push_back(i);
+                }
+                break;
+                case index_constraint::independent: {
+                    partitioned_indices.independent_indices.push_back(i);
+                }
+                break;
+                case index_constraint::constant: {
+                    partitioned_indices.constant_indices.push_back(i);
+                }
+                break;
+                case index_constraint::contiguous: {
+                    partitioned_indices.contiguous_indices.push_back(i);
+                }
+                break;
+            }
+        }
+ 
+        if(simd_width_ != 1) {
+            unsigned size_of_constant_section = ((width + (simd_width_ - 1))/ simd_width_) -
+                                                (partitioned_indices.serialized_indices.size() +
+                                                 partitioned_indices.independent_indices.size() +
+                                                 partitioned_indices.contiguous_indices.size() );
+ 
+            partitioned_indices.constant_indices.resize(size_of_constant_section);
+        }
+        else {
+            partitioned_indices.contiguous_indices.resize(width);
+        }
+ 
+        partitioned_indices.size = node_index.size();
+ 
+    }
+  
+    template <typename T>
+    bool compatible_constraint_indices(const T& node_index, const T& ion_index){
+        for (unsigned i = 0; i < node_index.size(); i+= simd_width_) {
+            index_constraint node_constraint = get_subvector_index_constraint(node_index, i);
+            index_constraint ion_constraint = get_subvector_index_constraint(ion_index, i);
+            if(node_constraint != ion_constraint) {
+                if(!((node_constraint == index_constraint::none) ||
+                   (node_constraint == index_constraint::independent &&
+                    ion_constraint == index_constraint::contiguous))) {
+                    std::cout << static_cast<std::underlying_type<index_constraint>::type>(node_constraint)<<std::endl;
+                    std::cout << static_cast<std::underlying_type<index_constraint>::type>(ion_constraint)<<std::endl;
+                    return false;
+                }
+            }
+ 
+        }
+        return true;
+    }
 
 } // namespace util
 } // namespace arb

--- a/src/backends/multicore/partition_by_constraint.hpp
+++ b/src/backends/multicore/partition_by_constraint.hpp
@@ -7,9 +7,9 @@ namespace arb {
 namespace multicore {
 
 namespace S = ::arb::simd;
-static constexpr unsigned simd_width_ = S::simd_abi::native_width<fvm_value_type>::value;
+using S::index_constraint;
 
-struct constraint_partitions {
+struct constraint_partition {
     using iarray = arb::multicore::iarray;
 
     iarray contiguous;
@@ -18,86 +18,94 @@ struct constraint_partitions {
     iarray none;
 };
 
-template <typename T>
-bool is_contiguous(const T& node_index, unsigned i) {
-    for (unsigned j = i + 1; j < i + simd_width_; j++) {
-        if(node_index[j] != node_index[j - 1] + 1)
+template <typename It>
+bool is_contiguous_n(It first, unsigned width) {
+    while (--width) {
+        It next = first;
+        if ((*first) +1 != *++next) {
             return false;
+        }
+        first = next;
     }
     return true;
 }
 
-template <typename T>
-bool is_constant(const T& node_index, unsigned i) {
-    for (unsigned j = i + 1; j < i + simd_width_; j++) {
-        if(node_index[j] != node_index[j - 1])
+template <typename It>
+bool is_constant_n(It first, unsigned width) {
+    while (--width) {
+        It next = first;
+        if (*first != *++next) {
             return false;
+        }
+        first = next;
     }
     return true;
 }
 
-template <typename T>
-bool is_independent(const T& node_index, unsigned i) {
-    for (unsigned j = i + 1; j < i + simd_width_; j++) {
-        if(node_index[j] == node_index[j - 1])
+template <typename It>
+bool is_independent_n(It first, unsigned width) {
+    while (--width) {
+        It next = first;
+        if (*first == *++next) {
             return false;
+        }
+        first = next;
     }
     return true;
 }
 
-template <typename T>
-index_constraint get_subvector_index_constraint(const T& node_index, unsigned i) {
-
-    if (is_contiguous(node_index, i))
+template <typename It>
+index_constraint idx_constraint(It it, unsigned simd_width) {
+    if (is_contiguous_n(it, simd_width)) {
         return index_constraint::contiguous;
-
-    else if (is_constant(node_index, i))
+    }
+    else if (is_constant_n(it, simd_width)) {
         return index_constraint::constant;
-
-    else if (is_independent(node_index, i))
+    }
+    else if (is_independent_n(it, simd_width)) {
         return index_constraint::independent;
-
-    else
+    }
+    else {
         return index_constraint::none;
+    }
 }
 
 template <typename T>
-void generate_index_constraint_partitions(const T& node_index, constraint_partitions& partitions, unsigned width) {
+constraint_partition make_constraint_partition(const T& node_index, unsigned width, unsigned simd_width) {
 
-    for (unsigned i = 0; i < width; i+= simd_width_) {
-        index_constraint constraint = get_subvector_index_constraint(node_index, i);
-        switch(constraint) {
-            case index_constraint::none: {
-                partitions.none.push_back(i);
-            }
-            break;
-            case index_constraint::independent: {
-                partitions.independent.push_back(i);
-            }
-            break;
-            case index_constraint::constant: {
-                partitions.constant.push_back(i);
-            }
-            break;
-            case index_constraint::contiguous: {
-                partitions.contiguous.push_back(i);
-            }
-            break;
+    constraint_partition part;
+    for (unsigned i = 0; i < width; i+= simd_width) {
+        auto ptr = &node_index[i];
+        if (is_contiguous_n(ptr, simd_width)) {
+            part.contiguous.push_back(i);
+        }
+        else if (is_constant_n(ptr, simd_width)) {
+            part.constant.push_back(i);
+        }
+        else if (is_independent_n(ptr, simd_width)) {
+            part.independent.push_back(i);
+        }
+        else {
+            part.none.push_back(i);
         }
     }
+    return part;
+}
+
+bool constexpr is_constraint_stronger(index_constraint a, index_constraint b) {
+    return a==b ||
+           a==index_constraint::none ||
+           (a==index_constraint::independent && b==index_constraint::contiguous);
 }
 
 template <typename T>
-bool compatible_index_constraints(const T& node_index, const T& ion_index){
-    for (unsigned i = 0; i < node_index.size(); i+= simd_width_) {
-        index_constraint node_constraint = get_subvector_index_constraint(node_index, i);
-        index_constraint ion_constraint = get_subvector_index_constraint(ion_index, i);
-        if(node_constraint != ion_constraint) {
-            if(!((node_constraint == index_constraint::none) ||
-               (node_constraint == index_constraint::independent &&
-                ion_constraint == index_constraint::contiguous))) {
-                return false;
-            }
+bool compatible_index_constraints(T& node_index, T& ion_index, unsigned simd_width){
+    for (unsigned i = 0; i < node_index.size(); i+= simd_width) {
+        auto nc = idx_constraint(&node_index[i], simd_width);
+        auto ic = idx_constraint(&ion_index[i], simd_width);
+
+        if (!is_constraint_stronger(nc, ic)) {
+            return false;
         }
     }
     return true;

--- a/src/backends/multicore/partition_by_constraint.hpp
+++ b/src/backends/multicore/partition_by_constraint.hpp
@@ -12,7 +12,6 @@ static constexpr unsigned simd_width_ = S::simd_abi::native_width<fvm_value_type
 struct constraint_partitions {
     using iarray = arb::multicore::iarray;
 
-    static constexpr int num_compartments = 4;
     iarray contiguous;
     iarray constant;
     iarray independent;
@@ -65,7 +64,7 @@ index_constraint get_subvector_index_constraint(const T& node_index, unsigned i)
 template <typename T>
 void generate_index_constraint_partitions(const T& node_index, constraint_partitions& partitions, unsigned width) {
 
-    for (unsigned i = 0; i < node_index.size(); i+= simd_width_) {
+    for (unsigned i = 0; i < width; i+= simd_width_) {
         index_constraint constraint = get_subvector_index_constraint(node_index, i);
         switch(constraint) {
             case index_constraint::none: {
@@ -86,19 +85,6 @@ void generate_index_constraint_partitions(const T& node_index, constraint_partit
             break;
         }
     }
-
-    if(simd_width_ != 1) {
-        unsigned size_of_constant_section = ((width + (simd_width_ - 1))/ simd_width_) -
-                                            (partitions.none.size() +
-                                             partitions.independent.size() +
-                                             partitions.contiguous.size() );
-
-        partitions.constant.resize(size_of_constant_section);
-    }
-    else {
-        partitions.contiguous.resize(width);
-    }
-
 }
 
 template <typename T>

--- a/src/common_types.hpp
+++ b/src/common_types.hpp
@@ -49,6 +49,17 @@ struct cell_member_type {
     cell_lid_type index;
 };
 
+// Constraints on possible index conflicts can be used to select a more
+// efficient indexed update, gather or scatter.
+
+enum class index_constraint {
+    none = 0,
+    // For indices k[0], k[1],...:
+    independent, // k[i]==k[j] => i=j.
+    contiguous,  // k[i]==k[0]+i
+    constant     // k[i]==k[j] ∀ i, j
+};
+
 DEFINE_LEXICOGRAPHIC_ORDERING(cell_member_type,(a.gid,a.index),(b.gid,b.index))
 
 // For storing time values [ms]

--- a/src/common_types.hpp
+++ b/src/common_types.hpp
@@ -49,17 +49,6 @@ struct cell_member_type {
     cell_lid_type index;
 };
 
-// Constraints on possible index conflicts can be used to select a more
-// efficient indexed update, gather or scatter.
-
-enum class index_constraint {
-    none = 0,
-    // For indices k[0], k[1],...:
-    independent, // k[i]==k[j] => i=j.
-    contiguous,  // k[i]==k[0]+i
-    constant     // k[i]==k[j] ∀ i, j
-};
-
 DEFINE_LEXICOGRAPHIC_ORDERING(cell_member_type,(a.gid,a.index),(b.gid,b.index))
 
 // For storing time values [ms]

--- a/src/fvm_lowered_cell_impl.hpp
+++ b/src/fvm_lowered_cell_impl.hpp
@@ -55,6 +55,10 @@ public:
         bool check_physical = false) override;
 
     value_type time() const override { return tmin_; }
+    
+    std::vector<mechanism_ptr>& mechanisms() {
+        return mechanisms_;
+    }
 
 private:
     // Host or GPU-side back-end dependent storage.

--- a/src/fvm_lowered_cell_impl.hpp
+++ b/src/fvm_lowered_cell_impl.hpp
@@ -56,6 +56,11 @@ public:
 
     value_type time() const override { return tmin_; }
 
+    //Exposed for testing purposes
+    std::vector<mechanism_ptr>& mechanisms() {
+        return mechanisms_;
+    }
+
 private:
     // Host or GPU-side back-end dependent storage.
     using array = typename backend::array;

--- a/src/fvm_lowered_cell_impl.hpp
+++ b/src/fvm_lowered_cell_impl.hpp
@@ -55,10 +55,6 @@ public:
         bool check_physical = false) override;
 
     value_type time() const override { return tmin_; }
-    
-    std::vector<mechanism_ptr>& mechanisms() {
-        return mechanisms_;
-    }
 
 private:
     // Host or GPU-side back-end dependent storage.

--- a/src/simd/implbase.hpp
+++ b/src/simd/implbase.hpp
@@ -435,44 +435,6 @@ struct implbase {
         }
     }
 
-    template <typename ImplIndex>
-    static void compound_indexed_add(tag<ImplIndex> tag, const vector_type& s, scalar_type* p, const typename ImplIndex::vector_type& index, index_constraint constraint) {
-        switch (constraint) {
-        case index_constraint::none:
-            {
-                typename ImplIndex::scalar_type o[width];
-                ImplIndex::copy_to(index, o);
-
-                store a;
-                I::copy_to(s, a);
-
-                for (unsigned i = 0; i<width; ++i) {
-                    p[o[i]] += a[i];
-                }
-            }
-            break;
-        case index_constraint::independent:
-            {
-                vector_type v = I::add(I::gather(tag, p, index), s);
-                I::scatter(tag, v, p, index);
-            }
-            break;
-        case index_constraint::contiguous:
-            {
-                p += ImplIndex::element0(index);
-                vector_type v = I::add(I::copy_from(p), s);
-                I::copy_to(v, p);
-            }
-            break;
-        case index_constraint::constant:
-            {
-                p += ImplIndex::element0(index);
-                *p += I::reduce_add(s);
-            }
-            break;
-        }
-    }
-
     static scalar_type reduce_add(const vector_type& s) {
         store a;
         I::copy_to(s, a);

--- a/src/simd/implbase.hpp
+++ b/src/simd/implbase.hpp
@@ -51,19 +51,6 @@
 
 namespace arb {
 namespace simd {
-
-// Constraints on possible index conflicts can be used to select a more
-// efficient indexed update, gather or scatter.
-
-enum class index_constraint {
-    none = 0,
-    // For indices k[0], k[1],...:
-
-    independent, // k[i]==k[j] => i=j.
-    contiguous,  // k[i]==k[0]+i
-    constant     // k[i]==k[j] ∀ i, j
-};
-
 namespace simd_detail {
 
 // The simd_traits class provides the mapping between a concrete SIMD

--- a/src/simd/implbase.hpp
+++ b/src/simd/implbase.hpp
@@ -51,6 +51,18 @@
 
 namespace arb {
 namespace simd {
+
+// Constraints on possible index conflicts can be used to select a more
+// efficient indexed update, gather or scatter.
+
+enum class index_constraint {
+    none = 0,
+    // For indices k[0], k[1],...:
+    independent, // k[i]==k[j] => i=j.
+    contiguous,  // k[i]==k[0]+i
+    constant     // k[i]==k[j] ∀ i, j
+};
+
 namespace simd_detail {
 
 // The simd_traits class provides the mapping between a concrete SIMD

--- a/src/simd/simd.hpp
+++ b/src/simd/simd.hpp
@@ -178,7 +178,9 @@ namespace simd_detail {
                 break;
                 case index_constraint::constant:
                 {
-                    value_ = Impl::gather(tag<IndexImpl>{}, pi.p, pi.index);
+                    scalar_type* p = IndexImpl::element0(pi.index) + pi.p;
+                    scalar_type l = (*p);
+                    value_ = Impl::broadcast(l);
                 }
                 break;
             }
@@ -205,7 +207,9 @@ namespace simd_detail {
                 break;
                 case index_constraint::constant:
                 {
-                    value_ = Impl::gather(tag<IndexImpl>{}, pi.p, pi.index);
+                    const scalar_type *p = IndexImpl::element0(pi.index) + pi.p;
+                    scalar_type l = (*p);
+                    value_ = Impl::broadcast(l);
                 }
                 break;
             }

--- a/src/simd/simd.hpp
+++ b/src/simd/simd.hpp
@@ -7,6 +7,7 @@
 #include <simd/implbase.hpp>
 #include <simd/generic.hpp>
 #include <simd/native.hpp>
+#include <common_types.hpp>
 
 namespace arb {
 namespace simd {

--- a/src/simd/simd.hpp
+++ b/src/simd/simd.hpp
@@ -160,23 +160,19 @@ namespace simd_detail {
         template <typename IndexImpl, typename = typename std::enable_if<width==simd_traits<IndexImpl>::width>::type>
         void copy_from(indirect_expression<IndexImpl, scalar_type> pi) {
             switch (pi.constraint) {
-                case index_constraint::none:
-                {
-                    value_ = Impl::gather(tag<IndexImpl>{}, pi.p, pi.index);
-                }
+            case index_constraint::none:
+                value_ = Impl::gather(tag<IndexImpl>{}, pi.p, pi.index);
                 break;
-                case index_constraint::independent:
-                {
-                    value_ = Impl::gather(tag<IndexImpl>{}, pi.p, pi.index);
-                }
+            case index_constraint::independent:
+                value_ = Impl::gather(tag<IndexImpl>{}, pi.p, pi.index);
                 break;
-                case index_constraint::contiguous:
+            case index_constraint::contiguous:
                 {
                     scalar_type* p = IndexImpl::element0(pi.index) + pi.p;
                     value_ = Impl::copy_from(p);
                 }
                 break;
-                case index_constraint::constant:
+            case index_constraint::constant:
                 {
                     scalar_type* p = IndexImpl::element0(pi.index) + pi.p;
                     scalar_type l = (*p);
@@ -189,23 +185,19 @@ namespace simd_detail {
         template <typename IndexImpl, typename = typename std::enable_if<width==simd_traits<IndexImpl>::width>::type>
         void copy_from(indirect_expression<IndexImpl, const scalar_type> pi) {
             switch (pi.constraint) {
-                case index_constraint::none:
-                {
-                    value_ = Impl::gather(tag<IndexImpl>{}, pi.p, pi.index);
-                }
+            case index_constraint::none:
+                value_ = Impl::gather(tag<IndexImpl>{}, pi.p, pi.index);
                 break;
-                case index_constraint::independent:
-                {
-                    value_ = Impl::gather(tag<IndexImpl>{}, pi.p, pi.index);
-                }
+            case index_constraint::independent:
+                value_ = Impl::gather(tag<IndexImpl>{}, pi.p, pi.index);
                 break;
-                case index_constraint::contiguous:
+            case index_constraint::contiguous:
                 {
                     const scalar_type* p = IndexImpl::element0(pi.index) + pi.p;
                     value_ = Impl::copy_from(p);
                 }
                 break;
-                case index_constraint::constant:
+            case index_constraint::constant:
                 {
                     const scalar_type *p = IndexImpl::element0(pi.index) + pi.p;
                     scalar_type l = (*p);
@@ -218,8 +210,8 @@ namespace simd_detail {
 
         template <typename ImplIndex>
         static void compound_indexed_add(tag<ImplIndex> tag, const vector_type& s, scalar_type* p, const typename ImplIndex::vector_type& index, index_constraint constraint) {
-            switch (constraint) {
-                case index_constraint::none:
+            switch (constraint) { 
+            case index_constraint::none:
                 {
                     typename ImplIndex::scalar_type o[width];
                     ImplIndex::copy_to(index, o);
@@ -228,28 +220,26 @@ namespace simd_detail {
                     Impl::copy_to(s, a);
 
                     for (unsigned i = 0; i<width; ++i) {
-                        p[o[i]] += a[i];
+                            p[o[i]] += a[i];
                     }
                 }
                 break;
-                case index_constraint::independent:
+            case index_constraint::independent:
                 {
                     vector_type v = Impl::add(Impl::gather(tag, p, index), s);
                     Impl::scatter(tag, v, p, index);
                 }
                 break;
-                case index_constraint::contiguous:
+            case index_constraint::contiguous:
                 {
                     p += ImplIndex::element0(index);
                     vector_type v = Impl::add(Impl::copy_from(p), s);
                     Impl::copy_to(v, p);
                 }
                 break;
-                case index_constraint::constant:
-                {
-                    p += ImplIndex::element0(index);
-                    *p += Impl::reduce_add(s);
-                }
+            case index_constraint::constant:
+                p += ImplIndex::element0(index);
+                *p += Impl::reduce_add(s);
                 break;
             }
         }

--- a/tests/ubench/CMakeLists.txt
+++ b/tests/ubench/CMakeLists.txt
@@ -7,6 +7,7 @@ set(bench_sources
     default_construct.cpp
     event_setup.cpp
     event_binning.cpp
+    mech_vec.cpp
 )
 
 set(bench_sources_cuda
@@ -43,6 +44,7 @@ foreach(bench_src ${bench_sources})
     add_dependencies("${bench_exe}" gbench)
     target_include_directories("${bench_exe}" PRIVATE "${gbench_install_dir}/include")
     target_link_libraries("${bench_exe}" LINK_PUBLIC "${gbench_install_dir}/lib/libbenchmark.a")
+    target_link_libraries("${bench_exe}" LINK_PUBLIC ${ARB_LIBRARIES})
 
     list(APPEND bench_exe_list ${bench_exe})
 endforeach()

--- a/tests/ubench/mech_vec.cpp
+++ b/tests/ubench/mech_vec.cpp
@@ -1,0 +1,448 @@
+// Test performance of vectorization for mechanism implementations.
+//
+// Start with pas (passive dendrite) mechanism
+
+#include <backends/multicore/fvm.hpp>
+#include <benchmark/benchmark.h>
+#include <fvm_lowered_cell_impl.hpp>
+#include <fstream>
+
+using namespace arb;
+
+using backend = arb::multicore::backend;
+using fvm_cell = arb::fvm_lowered_cell_impl<backend>;
+
+class recipe_expsyn_1_branch: public recipe {
+    unsigned num_comp_;
+    unsigned num_synapse_;
+public:
+    recipe_expsyn_1_branch(unsigned num_comp, unsigned num_synapse):
+            num_comp_(num_comp), num_synapse_(num_synapse) {}
+
+    cell_size_type num_cells() const override {
+        return 1;
+    }
+
+    virtual util::unique_any get_cell_description(cell_gid_type gid) const override {
+        cell c;
+
+        auto soma = c.add_soma(12.6157/2.0);
+        soma->add_mechanism("pas");
+
+        c.add_cable(0, section_kind::dendrite, 1.0/2, 1.0/2, 200.0);
+
+        for (auto& seg: c.segments()) {
+            if (seg->is_dendrite()) {
+                seg->set_compartments(num_comp_-1);
+            }
+        }
+
+        for(unsigned i = 0; i < num_synapse_; i++) {
+            float loc = ((float)i/(float)num_synapse_);
+            c.add_synapse({1, loc}, "expsyn");
+        }
+
+        return std::move(c);
+    }
+
+    virtual cell_kind get_cell_kind(cell_gid_type) const override {
+        return cell_kind::cable1d_neuron;
+    }
+
+};
+
+class recipe_pas_1_branch: public recipe {
+    unsigned num_comp_;
+public:
+    recipe_pas_1_branch(unsigned num_comp): num_comp_(num_comp) {}
+
+    cell_size_type num_cells() const override {
+        return 1;
+    }
+
+    virtual util::unique_any get_cell_description(cell_gid_type gid) const override {
+        cell c;
+
+        auto soma = c.add_soma(12.6157/2.0);
+        soma->add_mechanism("pas");
+
+        c.add_cable(0, section_kind::dendrite, 1.0/2, 1.0/2, 200.0);
+
+        for (auto& seg: c.segments()) {
+            if (seg->is_dendrite()) {
+                seg->add_mechanism("pas");
+                seg->set_compartments(num_comp_-1);
+            }
+        }
+        return std::move(c);
+    }
+
+    virtual cell_kind get_cell_kind(cell_gid_type) const override {
+        return cell_kind::cable1d_neuron;
+    }
+
+};
+
+class recipe_pas_3_branches: public recipe {
+    unsigned num_comp_;
+public:
+    recipe_pas_3_branches(unsigned num_comp): num_comp_(num_comp) {}
+
+    cell_size_type num_cells() const override {
+        return 1;
+    }
+
+    virtual util::unique_any get_cell_description(cell_gid_type gid) const override {
+        cell c;
+
+        auto soma = c.add_soma(12.6157/2.0);
+        soma->add_mechanism("pas");
+
+        c.add_cable(0, section_kind::dendrite, 1.0/2, 1.0/2, 200.0);
+        c.add_cable(1, section_kind::dendrite, 1.0/2, 1.0/2, 200.0);
+        c.add_cable(1, section_kind::dendrite, 1.0/2, 1.0/2, 200.0);
+
+        for (auto& seg: c.segments()) {
+            if (seg->is_dendrite()) {
+                seg->add_mechanism("pas");
+                seg->set_compartments(num_comp_-1);
+            }
+        }
+        return std::move(c);
+    }
+
+    virtual cell_kind get_cell_kind(cell_gid_type) const override {
+        return cell_kind::cable1d_neuron;
+    }
+
+};
+
+class recipe_hh_1_branch: public recipe {
+    unsigned num_comp_;
+public:
+    recipe_hh_1_branch(unsigned num_comp): num_comp_(num_comp) {}
+
+    cell_size_type num_cells() const override {
+        return 1;
+    }
+
+    virtual util::unique_any get_cell_description(cell_gid_type gid) const override {
+        cell c;
+
+        auto soma = c.add_soma(12.6157/2.0);
+        soma->add_mechanism("hh");
+
+        c.add_cable(0, section_kind::dendrite, 1.0/2, 1.0/2, 200.0);
+
+        for (auto& seg: c.segments()) {
+            if (seg->is_dendrite()) {
+                seg->add_mechanism("hh");
+                seg->set_compartments(num_comp_-1);
+            }
+        }
+        return std::move(c);
+    }
+
+    virtual cell_kind get_cell_kind(cell_gid_type) const override {
+        return cell_kind::cable1d_neuron;
+    }
+
+};
+
+class recipe_hh_3_branches: public recipe {
+    unsigned num_comp_;
+public:
+    recipe_hh_3_branches(unsigned num_comp): num_comp_(num_comp) {}
+
+    cell_size_type num_cells() const override {
+        return 1;
+    }
+
+    virtual util::unique_any get_cell_description(cell_gid_type gid) const override {
+        cell c;
+
+        auto soma = c.add_soma(12.6157/2.0);
+        soma->add_mechanism("pas");
+
+        c.add_cable(0, section_kind::dendrite, 1.0/2, 1.0/2, 200.0);
+        c.add_cable(1, section_kind::dendrite, 1.0/2, 1.0/2, 200.0);
+        c.add_cable(1, section_kind::dendrite, 1.0/2, 1.0/2, 200.0);
+
+        for (auto& seg: c.segments()) {
+            if (seg->is_dendrite()) {
+                seg->add_mechanism("hh");
+                seg->set_compartments(num_comp_-1);
+            }
+        }
+        return std::move(c);
+    }
+
+    virtual cell_kind get_cell_kind(cell_gid_type) const override {
+        return cell_kind::cable1d_neuron;
+    }
+
+    //virtual cell_size_type num_targets(cell_gid_type) const { return 0; }
+};
+
+void expsyn_1_branch_current(benchmark::State& state) {
+    const unsigned ncomp = state.range(0);
+    const unsigned nsynapse = state.range(1);
+    std::vector<cell_gid_type> gids = {0};
+    std::vector<target_handle> target_handles;
+    probe_association_map<probe_handle> probe_handles;
+    recipe_expsyn_1_branch recipe_expsyn_1_branch1(ncomp, nsynapse);
+
+    fvm_cell cell;
+    cell.initialize(gids, recipe_expsyn_1_branch1, target_handles, probe_handles);
+
+    int idx = -1;
+    auto &mechs = cell.mechanisms();
+    for (unsigned i=0; i<mechs.size(); ++i) {
+        if (mechs[i]->internal_name() == "expsyn") {
+            idx = i;
+            break;
+        }
+    }
+
+    if (idx==-1) {
+        std::cout << "ERROR: couldn't find pas\n";
+        exit(1);
+    }
+
+    auto& m = mechs[idx];
+    while (state.KeepRunning()) {
+        // call nrn_current
+        m->nrn_current();
+    }
+}
+
+void expsyn_1_branch_state(benchmark::State& state) {
+    const unsigned ncomp = state.range(0);
+    const unsigned nsynapse = state.range(1);
+    std::vector<cell_gid_type> gids = {0};
+    std::vector<target_handle> target_handles;
+    probe_association_map<probe_handle> probe_handles;
+    recipe_expsyn_1_branch recipe_expsyn_1_branch1(ncomp, nsynapse);
+
+    fvm_cell cell;
+    cell.initialize(gids, recipe_expsyn_1_branch1, target_handles, probe_handles);
+
+    int idx = -1;
+    auto &mechs = cell.mechanisms();
+    for (unsigned i=0; i<mechs.size(); ++i) {
+        if (mechs[i]->internal_name() == "expsyn") {
+            idx = i;
+            break;
+        }
+    }
+    if (idx==-1) {
+        std::cout << "ERROR: couldn't find pas\n";
+        exit(1);
+    }
+
+    auto& m = mechs[idx];
+    while (state.KeepRunning()) {
+        // call nrn_state
+        m->nrn_state();
+    }
+}
+
+void pas_1_branch_current(benchmark::State& state) {
+    const unsigned ncomp = state.range(0);
+    std::vector<cell_gid_type> gids = {0};
+    std::vector<target_handle> target_handles;
+    probe_association_map<probe_handle> probe_handles;
+    recipe_pas_1_branch rec_pas_1_branch(ncomp);
+
+    fvm_cell cell;
+    cell.initialize(gids, rec_pas_1_branch, target_handles, probe_handles);
+
+    int idx = -1;
+    auto &mechs = cell.mechanisms();
+    for (unsigned i=0; i<mechs.size(); ++i) {
+        if (mechs[i]->internal_name() == "pas") {
+            idx = i;
+			break;
+        }
+    }
+    if (idx==-1) {
+        std::cout << "ERROR: couldn't find pas\n";
+        exit(1);
+    }
+
+    auto& m = mechs[idx];
+    while (state.KeepRunning()) {
+        // call nrn_current
+        m->nrn_current();
+    }
+}
+
+void pas_3_branches_current(benchmark::State& state) {
+    const unsigned ncomp = state.range(0);
+    std::vector<cell_gid_type> gids = {0};
+    std::vector<target_handle> target_handles;
+    probe_association_map<probe_handle> probe_handles;
+    recipe_pas_3_branches rec_pas_3_branches(ncomp);
+
+    fvm_cell cell;
+    cell.initialize(gids, rec_pas_3_branches, target_handles, probe_handles);
+
+    int idx = -1;
+    auto &mechs = cell.mechanisms();
+    for (unsigned i=0; i<mechs.size(); ++i) {
+        if (mechs[i]->internal_name() == "pas") {
+            idx = i;
+			break;
+        }
+    }
+    if (idx==-1) {
+        std::cout << "ERROR: couldn't find pas\n";
+        exit(1);
+    }
+    auto& m = mechs[idx];
+
+    while (state.KeepRunning()) {
+        // call nrn_current
+        m->nrn_current();
+    }
+}
+
+void hh_1_branch_state(benchmark::State& state) {
+    const unsigned ncomp = state.range(0);
+    std::vector<cell_gid_type> gids = {0};
+    std::vector<target_handle> target_handles;
+    probe_association_map<probe_handle> probe_handles;
+    recipe_hh_1_branch rec_hh_1_branch(ncomp);
+
+    fvm_cell cell;
+    cell.initialize(gids, rec_hh_1_branch, target_handles, probe_handles);
+
+    int idx = -1;
+    auto &mechs = cell.mechanisms();
+    for (unsigned i=0; i<mechs.size(); ++i) {
+        if (mechs[i]->internal_name() == "hh") {
+            idx = i;
+			break;
+        }
+    }
+    if (idx==-1) {
+        std::cout << "ERROR: couldn't find hh\n";
+        exit(1);
+    }
+    auto& m = mechs[idx];
+
+    while (state.KeepRunning()) {
+        // call nrn_state
+        m->nrn_state();
+    }
+}
+
+void hh_1_branch_current(benchmark::State& state) {
+    const unsigned ncomp = state.range(0);
+    std::vector<cell_gid_type> gids = {0};
+    std::vector<target_handle> target_handles;
+    probe_association_map<probe_handle> probe_handles;
+    recipe_hh_1_branch rec_hh_1_branch(ncomp);
+
+    fvm_cell cell;
+    cell.initialize(gids, rec_hh_1_branch, target_handles, probe_handles);
+
+    int idx = -1;
+    auto &mechs = cell.mechanisms();
+    for (unsigned i=0; i<mechs.size(); ++i) {
+        if (mechs[i]->internal_name() == "hh") {
+            idx = i;
+			break;
+        }
+    }
+    if (idx==-1) {
+        std::cout << "ERROR: couldn't find hh\n";
+        exit(1);
+    }
+    auto& m = mechs[idx];
+
+    while (state.KeepRunning()) {
+        // call nrn_current
+        m->nrn_current();
+    }
+}
+
+void hh_3_branches_state(benchmark::State& state) {
+    const unsigned ncomp = state.range(0);
+    std::vector<cell_gid_type> gids = {0};
+    std::vector<target_handle> target_handles;
+    probe_association_map<probe_handle> probe_handles;
+    recipe_hh_3_branches rec_hh_3_branches(ncomp);
+
+    fvm_cell cell;
+    cell.initialize(gids, rec_hh_3_branches, target_handles, probe_handles);
+
+    int idx = -1;
+    auto &mechs = cell.mechanisms();
+    for (unsigned i=0; i<mechs.size(); ++i) {
+        if (mechs[i]->internal_name() == "hh") {
+            idx = i;
+			break;
+        }
+    }
+    if (idx==-1) {
+        std::cout << "ERROR: couldn't find hh\n";
+        exit(1);
+    }
+    auto& m = mechs[idx];
+
+    while (state.KeepRunning()) {
+        // call nrn_state
+        m->nrn_state();
+    }
+}
+
+void hh_3_branches_current(benchmark::State& state) {
+    const unsigned ncomp = state.range(0);
+    std::vector<cell_gid_type> gids = {0};
+    std::vector<target_handle> target_handles;
+    probe_association_map<probe_handle> probe_handles;
+    recipe_hh_3_branches rec_hh_3_branches(ncomp);
+
+    fvm_cell cell;
+    cell.initialize(gids, rec_hh_3_branches, target_handles, probe_handles);
+
+    int idx = -1;
+    auto &mechs = cell.mechanisms();
+    for (unsigned i=0; i<mechs.size(); ++i) {
+        if (mechs[i]->internal_name() == "hh") {
+            idx = i;
+			break;
+        }
+    }
+    if (idx==-1) {
+        std::cout << "ERROR: couldn't find hh\n";
+        exit(1);
+    }
+    auto& m = mechs[idx];
+
+    while (state.KeepRunning()) {
+        // call nrn_current
+        m->nrn_current();
+    }
+}
+
+void run_custom_arguments(benchmark::internal::Benchmark* b) {
+    for (auto ncomps: {10, 100, 1000, 10000, 100000, 1000000, 10000000}) {
+        b->Args({ncomps});
+    }
+}
+void run_exp_custom_arguments(benchmark::internal::Benchmark* b) {
+    for (auto ncomps: {10, 100, 1000, 10000, 100000, 1000000, 10000000}) {
+        b->Args({ncomps, ncomps*10});
+    }
+}
+BENCHMARK(expsyn_1_branch_current)->Apply(run_exp_custom_arguments);
+BENCHMARK(expsyn_1_branch_state)->Apply(run_exp_custom_arguments);
+/*BENCHMARK(pas_1_branch_current)->Apply(run_custom_arguments);
+BENCHMARK(hh_1_branch_current)->Apply(run_custom_arguments);
+BENCHMARK(hh_1_branch_state)->Apply(run_custom_arguments);
+BENCHMARK(pas_3_branches_current)->Apply(run_custom_arguments);
+BENCHMARK(hh_3_branches_current)->Apply(run_custom_arguments);
+BENCHMARK(hh_3_branches_state)->Apply(run_custom_arguments);*/
+BENCHMARK_MAIN();

--- a/tests/ubench/mech_vec.cpp
+++ b/tests/ubench/mech_vec.cpp
@@ -432,17 +432,17 @@ void run_custom_arguments(benchmark::internal::Benchmark* b) {
         b->Args({ncomps});
     }
 }
-void run_exp_custom_arguments(benchmark::internal::Benchmark* b) {
+void run_expsyn_custom_arguments(benchmark::internal::Benchmark* b) {
     for (auto ncomps: {10, 100, 1000, 10000, 100000, 1000000, 10000000}) {
         b->Args({ncomps, ncomps*10});
     }
 }
 BENCHMARK(expsyn_1_branch_current)->Apply(run_exp_custom_arguments);
 BENCHMARK(expsyn_1_branch_state)->Apply(run_exp_custom_arguments);
-/*BENCHMARK(pas_1_branch_current)->Apply(run_custom_arguments);
+BENCHMARK(pas_1_branch_current)->Apply(run_custom_arguments);
 BENCHMARK(hh_1_branch_current)->Apply(run_custom_arguments);
 BENCHMARK(hh_1_branch_state)->Apply(run_custom_arguments);
 BENCHMARK(pas_3_branches_current)->Apply(run_custom_arguments);
 BENCHMARK(hh_3_branches_current)->Apply(run_custom_arguments);
-BENCHMARK(hh_3_branches_state)->Apply(run_custom_arguments);*/
+BENCHMARK(hh_3_branches_state)->Apply(run_custom_arguments);
 BENCHMARK_MAIN();

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -69,6 +69,7 @@ set(test_sources
     test_mechinfo.cpp
     test_padded.cpp
     test_partition.cpp
+    test_partition_by_constraint.cpp
     test_path.cpp
     test_point.cpp
     test_probe.cpp

--- a/tests/unit/test_partition_by_constraint.cpp
+++ b/tests/unit/test_partition_by_constraint.cpp
@@ -16,117 +16,134 @@ static constexpr unsigned simd_width_ = arb::simd::simd_abi::native_width<fvm_va
 
 const int input_size_ = 1024;
 
-enum index_constraint {
-    contiguous= 0,
-    independent,
-    none,
-    constant
-};
-
 TEST(partition_by_constraint, partition_contiguous) {
     iarray input_index(input_size_);
-    multicore::constraint_partition output_constraint;
+    iarray expected_indices;
+    multicore::constraint_partitions output_constraint;
+
 
     for (unsigned i = 0; i < input_size_; i++) {
         input_index[i] = i;
+        if(i % simd_width_ == 0)
+            expected_indices.push_back(i);
     }
 
-    multicore::gen_constraint(input_index, output_constraint);
+    multicore::gen_constraint(input_index, output_constraint, input_size_);
 
-    EXPECT_EQ(input_size_, output_constraint.compartment_sizes[contiguous]);
-    EXPECT_EQ(0, output_constraint.compartment_sizes[constant]);
-    EXPECT_EQ(0, output_constraint.compartment_sizes[independent]);
-    EXPECT_EQ(0, output_constraint.compartment_sizes[none]);
+    EXPECT_EQ(input_size_/simd_width_, output_constraint.contiguous_indices.size());
+    EXPECT_EQ(0, output_constraint.constant_indices.size());
+    EXPECT_EQ(0, output_constraint.independent_indices.size());
+    EXPECT_EQ(0, output_constraint.serialized_indices.size());
 
-    for (unsigned i = 0; i < input_size_; i++) {
-        EXPECT_EQ(output_constraint.full_index_compartments[i],
-                  input_index[i]);
+    for (unsigned i = 0; i < input_size_ / simd_width_; i++) {
+        EXPECT_EQ(expected_indices[i], output_constraint.contiguous_indices[i]);
     }
 }
 
 TEST(partition_by_constraint, partition_constant) {
     iarray input_index(input_size_);
-    multicore::constraint_partition output_constraint;
+    iarray expected_indices;
+    multicore::constraint_partitions output_constraint;
 
     const int c = 5;
 
     for (unsigned i = 0; i < input_size_; i++) {
         input_index[i] = c;
+        if(i % simd_width_ == 0)
+            expected_indices.push_back(i);
     }
 
-    multicore::gen_constraint(input_index, output_constraint);
+    multicore::gen_constraint(input_index, output_constraint, input_size_);
+
     if(simd_width_ != 1) {
-        EXPECT_EQ(input_size_, output_constraint.compartment_sizes[constant]);
-        EXPECT_EQ(0, output_constraint.compartment_sizes[contiguous]);
+        EXPECT_EQ(input_size_/simd_width_, output_constraint.constant_indices.size());
+        EXPECT_EQ(0, output_constraint.contiguous_indices.size());
     }
     else {
-        EXPECT_EQ(0, output_constraint.compartment_sizes[constant]);
-        EXPECT_EQ(input_size_, output_constraint.compartment_sizes[contiguous]);
+        EXPECT_EQ(0, output_constraint.constant_indices.size());
+        EXPECT_EQ(input_size_/simd_width_, output_constraint.contiguous_indices.size());
     }
-    EXPECT_EQ(0, output_constraint.compartment_sizes[independent]);
-    EXPECT_EQ(0, output_constraint.compartment_sizes[none]);
+    EXPECT_EQ(0, output_constraint.independent_indices.size());
+    EXPECT_EQ(0, output_constraint.serialized_indices.size());
 
-    for (unsigned i = 0; i < input_size_; i++) {
-            EXPECT_EQ(output_constraint.full_index_compartments[i], input_index[i]);
+    for (unsigned i = 0; i < input_size_ / simd_width_; i++) {
+        if(simd_width_ != 1)
+            EXPECT_EQ(expected_indices[i], output_constraint.constant_indices[i]);
+        else
+            EXPECT_EQ(expected_indices[i], output_constraint.contiguous_indices[i]);
     }
 }
 
 TEST(partition_by_constraint, partition_independent) {
     iarray input_index(input_size_);
-    multicore::constraint_partition output_constraint;
+    iarray expected_indices;
+    multicore::constraint_partitions output_constraint;
 
     for (unsigned i = 0; i < input_size_; i++) {
         input_index[i] = i * 2;
+        if(i % simd_width_ == 0)
+            expected_indices.push_back(i);
     }
 
-    multicore::gen_constraint(input_index, output_constraint);
+    multicore::gen_constraint(input_index, output_constraint, input_size_);
 
     if(simd_width_ != 1) {
-        EXPECT_EQ(input_size_, output_constraint.compartment_sizes[independent]);
-        EXPECT_EQ(0, output_constraint.compartment_sizes[contiguous]);
+        EXPECT_EQ(input_size_/simd_width_, output_constraint.independent_indices.size());
+        EXPECT_EQ(0, output_constraint.contiguous_indices.size());
     }
     else {
-        EXPECT_EQ(0, output_constraint.compartment_sizes[independent]);
-        EXPECT_EQ(input_size_, output_constraint.compartment_sizes[contiguous]);
+        EXPECT_EQ(0, output_constraint.independent_indices.size());
+        EXPECT_EQ(input_size_/simd_width_, output_constraint.contiguous_indices.size());
     }
-    EXPECT_EQ(0, output_constraint.compartment_sizes[constant]);
-    EXPECT_EQ(0, output_constraint.compartment_sizes[none]);
+    EXPECT_EQ(0, output_constraint.constant_indices.size());
+    EXPECT_EQ(0, output_constraint.serialized_indices.size());
 
-
-    for (unsigned i = 0; i < input_size_; i++) {
-            EXPECT_EQ(output_constraint.full_index_compartments[i], input_index[i]);
+    for (unsigned i = 0; i < input_size_ / simd_width_; i++) {
+        if(simd_width_ != 1)
+            EXPECT_EQ(expected_indices[i], output_constraint.independent_indices[i]);
+        else
+            EXPECT_EQ(expected_indices[i], output_constraint.contiguous_indices[i]);
     }
 }
 
 TEST(partition_by_constraint, partition_serial) {
     iarray input_index(input_size_);
-    multicore::constraint_partition output_constraint;
+    iarray expected_indices;
+    multicore::constraint_partitions output_constraint;
 
     for (unsigned i = 0; i < input_size_; i++) {
         input_index[i] = i / ((simd_width_ + 1)/ 2);
+        if(i % simd_width_ == 0)
+            expected_indices.push_back(i);
     }
 
-    multicore::gen_constraint(input_index, output_constraint);
+    multicore::gen_constraint(input_index, output_constraint, input_size_);
+
     if(simd_width_ != 1) {
-        EXPECT_EQ(input_size_, output_constraint.compartment_sizes[none]);
-        EXPECT_EQ(0, output_constraint.compartment_sizes[contiguous]);
+        EXPECT_EQ(input_size_/simd_width_, output_constraint.serialized_indices.size());
+        EXPECT_EQ(0, output_constraint.contiguous_indices.size());
     }
     else {
-        EXPECT_EQ(0, output_constraint.compartment_sizes[none]);
-        EXPECT_EQ(input_size_, output_constraint.compartment_sizes[contiguous]);
+        EXPECT_EQ(0, output_constraint.serialized_indices.size());
+        EXPECT_EQ(input_size_/simd_width_, output_constraint.contiguous_indices.size());
     }
+    EXPECT_EQ(0, output_constraint.independent_indices.size());
+    EXPECT_EQ(0, output_constraint.constant_indices.size());
 
-    EXPECT_EQ(0, output_constraint.compartment_sizes[independent]);
-    EXPECT_EQ(0, output_constraint.compartment_sizes[constant]);
-
-    for (unsigned i = 0; i < input_size_; i++) {
-        EXPECT_EQ(output_constraint.full_index_compartments[i], input_index[i]);
+    for (unsigned i = 0; i < input_size_ / simd_width_; i++) {
+        if(simd_width_ != 1)
+            EXPECT_EQ(expected_indices[i], output_constraint.serialized_indices[i]);
+        else
+            EXPECT_EQ(expected_indices[i], output_constraint.contiguous_indices[i]);
     }
 }
 
 TEST(partition_by_constraint, partition_random) {
     iarray input_index(input_size_);
-    multicore::constraint_partition output_constraint;
+    iarray expected_indices_contiguous, expected_indices_constant,
+            expected_indices_independent, expected_indices_serial;
+    multicore::constraint_partitions output_constraint;
+
 
     const int c = 5;
 //shuffle here
@@ -134,41 +151,96 @@ TEST(partition_by_constraint, partition_random) {
         input_index[i] = (i < input_size_ / 4 ? i / ((simd_width_ + 1)/ 2) :
                           (i < input_size_ / 2 ? i * 2 :
                            (i < input_size_* 3 / 4 ? c : i)));
+        if (i < input_size_ / 4 && i % simd_width_ == 0)
+            expected_indices_serial.push_back(i);
+        else if (i < input_size_ / 2 && i % simd_width_ == 0)
+            expected_indices_independent.push_back(i);
+        else if (i < input_size_* 3/ 4 && i % simd_width_ == 0)
+            expected_indices_constant.push_back(i);
+        else if (i % simd_width_ == 0)
+            expected_indices_contiguous.push_back(i);
     }
 
-    multicore::gen_constraint(input_index, output_constraint);
+    multicore::gen_constraint(input_index, output_constraint, input_size_);
 
     if (simd_width_ != 1) {
-        EXPECT_EQ(input_size_ / 4, output_constraint.compartment_sizes[contiguous]);
-        EXPECT_EQ(input_size_ / 4, output_constraint.compartment_sizes[constant]);
-        EXPECT_EQ(input_size_ / 4, output_constraint.compartment_sizes[independent]);
-        EXPECT_EQ(input_size_ / 4, output_constraint.compartment_sizes[none]);
+        EXPECT_EQ(input_size_ / 4 / simd_width_, output_constraint.contiguous_indices.size());
+        EXPECT_EQ(input_size_ / 4 / simd_width_, output_constraint.constant_indices.size());
+        EXPECT_EQ(input_size_ / 4 / simd_width_, output_constraint.independent_indices.size());
+        EXPECT_EQ(input_size_ / 4 / simd_width_, output_constraint.serialized_indices.size());
     }
     else {
-        EXPECT_EQ(input_size_, output_constraint.compartment_sizes[contiguous]);
-        EXPECT_EQ(0, output_constraint.compartment_sizes[constant]);
-        EXPECT_EQ(0, output_constraint.compartment_sizes[independent]);
-        EXPECT_EQ(0, output_constraint.compartment_sizes[none]);
+        EXPECT_EQ(input_size_ / simd_width_, output_constraint.contiguous_indices.size());
+        EXPECT_EQ(0, output_constraint.constant_indices.size());
+        EXPECT_EQ(0, output_constraint.independent_indices.size());
+        EXPECT_EQ(0, output_constraint.serialized_indices.size());
     }
 
-    for (unsigned i = 0; i < input_size_; i++) {
-        if (simd_width_ != 1) {
-            if (i < input_size_ / 4)
-                EXPECT_EQ(output_constraint.full_index_compartments[i + input_size_ / 2],
-                          input_index[i]);
-            else if (i < input_size_ / 2)
-                EXPECT_EQ(output_constraint.full_index_compartments[i],
-                          input_index[i]);
-            else if (i < input_size_ * 3 / 4)
-                EXPECT_EQ(output_constraint.full_index_compartments[i + input_size_ / 4],
-                          input_index[i]);
-            else
-                EXPECT_EQ(output_constraint.full_index_compartments[i - input_size_ * 3 / 4],
-                          input_index[i]);
+    if (simd_width_ != 1) {
+        for (unsigned i = 0; i < input_size_ / simd_width_ / 4; i++) {
+            EXPECT_EQ(expected_indices_contiguous[i], output_constraint.contiguous_indices[i]);
+            EXPECT_EQ(expected_indices_constant[i], output_constraint.constant_indices[i]);
+            EXPECT_EQ(expected_indices_independent[i], output_constraint.independent_indices[i]);
+            EXPECT_EQ(expected_indices_serial[i], output_constraint.serialized_indices[i]);
         }
-        else {
-            EXPECT_EQ(output_constraint.full_index_compartments[i],
-                      input_index[i]);
+    }
+    else {
+        for (unsigned i = 0; i < input_size_ / simd_width_; i++) {
+            EXPECT_EQ(i, output_constraint.contiguous_indices[i]);
+        }
+    }
+}
+
+TEST(partition_by_constraint, partition_subvector_constraint_categorization) {
+    iarray input_index(input_size_);
+    multicore::constraint_partitions output_constraint;
+
+    if(simd_width_ == 4) {
+        {
+            iarray input_index_constant0;
+            for (unsigned i = 0; i < simd_width_; i++) {
+                input_index_constant0.push_back(0);
+            }
+            EXPECT_EQ(multicore::get_subvector_index_constraint(input_index_constant0, 0), index_constraint::constant);
+        }
+
+        {
+            iarray input_index_contiguous0;
+            for (unsigned i = 0; i < simd_width_; i++) {
+                input_index_contiguous0.push_back(i);
+            }
+            EXPECT_EQ(multicore::get_subvector_index_constraint(input_index_contiguous0, 0),
+                      index_constraint::contiguous);
+        }
+
+        {
+            iarray input_index_independent0;
+            for (unsigned i = 0; i < simd_width_; i++) {
+                input_index_independent0.push_back(i * 2);
+            }
+            EXPECT_EQ(multicore::get_subvector_index_constraint(input_index_independent0, 0),
+                      index_constraint::independent);
+        }
+
+        {
+            iarray input_index_serial0;
+            for (unsigned i = 0; i < simd_width_; i++) {
+                input_index_serial0.push_back(i / 2);
+            }
+            EXPECT_EQ(multicore::get_subvector_index_constraint(input_index_serial0, 0), index_constraint::none);
+        }
+
+        {
+            iarray input_index_serial1 = iarray{1, 2, 2, 4};
+            EXPECT_EQ(multicore::get_subvector_index_constraint(input_index_serial1, 0), index_constraint::none);
+        }
+
+
+        {
+            iarray input_index_independent1 = iarray{0, 2, 656, 900};
+            EXPECT_EQ(multicore::get_subvector_index_constraint(input_index_independent1, 0),
+                      index_constraint::independent);
+
         }
     }
 }

--- a/tests/unit/test_partition_by_constraint.cpp
+++ b/tests/unit/test_partition_by_constraint.cpp
@@ -1,0 +1,174 @@
+#include "../gtest.h"
+
+#include <array>
+#include <forward_list>
+#include <string>
+#include <vector>
+
+#include <simd/simd.hpp>
+#include <common_types.hpp>
+#include <backends/multicore/multicore_common.hpp>
+#include <backends/multicore/partition_by_constraint.hpp>
+
+using namespace arb;
+using iarray = multicore::iarray;
+static constexpr unsigned simd_width_ = arb::simd::simd_abi::native_width<fvm_value_type>::value;
+
+const int input_size_ = 1024;
+
+enum index_constraint {
+    contiguous= 0,
+    independent,
+    none,
+    constant
+};
+
+TEST(partition_by_constraint, partition_contiguous) {
+    iarray input_index(input_size_);
+    multicore::constraint_partition output_constraint;
+
+    for (unsigned i = 0; i < input_size_; i++) {
+        input_index[i] = i;
+    }
+
+    multicore::gen_constraint(input_index, output_constraint);
+
+    EXPECT_EQ(input_size_, output_constraint.compartment_sizes[contiguous]);
+    EXPECT_EQ(0, output_constraint.compartment_sizes[constant]);
+    EXPECT_EQ(0, output_constraint.compartment_sizes[independent]);
+    EXPECT_EQ(0, output_constraint.compartment_sizes[none]);
+
+    for (unsigned i = 0; i < input_size_; i++) {
+        EXPECT_EQ(output_constraint.full_index_compartments[i],
+                  input_index[i]);
+    }
+}
+
+TEST(partition_by_constraint, partition_constant) {
+    iarray input_index(input_size_);
+    multicore::constraint_partition output_constraint;
+
+    const int c = 5;
+
+    for (unsigned i = 0; i < input_size_; i++) {
+        input_index[i] = c;
+    }
+
+    multicore::gen_constraint(input_index, output_constraint);
+    if(simd_width_ != 1) {
+        EXPECT_EQ(input_size_, output_constraint.compartment_sizes[constant]);
+        EXPECT_EQ(0, output_constraint.compartment_sizes[contiguous]);
+    }
+    else {
+        EXPECT_EQ(0, output_constraint.compartment_sizes[constant]);
+        EXPECT_EQ(input_size_, output_constraint.compartment_sizes[contiguous]);
+    }
+    EXPECT_EQ(0, output_constraint.compartment_sizes[independent]);
+    EXPECT_EQ(0, output_constraint.compartment_sizes[none]);
+
+    for (unsigned i = 0; i < input_size_; i++) {
+            EXPECT_EQ(output_constraint.full_index_compartments[i], input_index[i]);
+    }
+}
+
+TEST(partition_by_constraint, partition_independent) {
+    iarray input_index(input_size_);
+    multicore::constraint_partition output_constraint;
+
+    for (unsigned i = 0; i < input_size_; i++) {
+        input_index[i] = i * 2;
+    }
+
+    multicore::gen_constraint(input_index, output_constraint);
+
+    if(simd_width_ != 1) {
+        EXPECT_EQ(input_size_, output_constraint.compartment_sizes[independent]);
+        EXPECT_EQ(0, output_constraint.compartment_sizes[contiguous]);
+    }
+    else {
+        EXPECT_EQ(0, output_constraint.compartment_sizes[independent]);
+        EXPECT_EQ(input_size_, output_constraint.compartment_sizes[contiguous]);
+    }
+    EXPECT_EQ(0, output_constraint.compartment_sizes[constant]);
+    EXPECT_EQ(0, output_constraint.compartment_sizes[none]);
+
+
+    for (unsigned i = 0; i < input_size_; i++) {
+            EXPECT_EQ(output_constraint.full_index_compartments[i], input_index[i]);
+    }
+}
+
+TEST(partition_by_constraint, partition_serial) {
+    iarray input_index(input_size_);
+    multicore::constraint_partition output_constraint;
+
+    for (unsigned i = 0; i < input_size_; i++) {
+        input_index[i] = i / ((simd_width_ + 1)/ 2);
+    }
+
+    multicore::gen_constraint(input_index, output_constraint);
+    if(simd_width_ != 1) {
+        EXPECT_EQ(input_size_, output_constraint.compartment_sizes[none]);
+        EXPECT_EQ(0, output_constraint.compartment_sizes[contiguous]);
+    }
+    else {
+        EXPECT_EQ(0, output_constraint.compartment_sizes[none]);
+        EXPECT_EQ(input_size_, output_constraint.compartment_sizes[contiguous]);
+    }
+
+    EXPECT_EQ(0, output_constraint.compartment_sizes[independent]);
+    EXPECT_EQ(0, output_constraint.compartment_sizes[constant]);
+
+    for (unsigned i = 0; i < input_size_; i++) {
+        EXPECT_EQ(output_constraint.full_index_compartments[i], input_index[i]);
+    }
+}
+
+TEST(partition_by_constraint, partition_random) {
+    iarray input_index(input_size_);
+    multicore::constraint_partition output_constraint;
+
+    const int c = 5;
+//shuffle here
+    for (unsigned i = 0; i < input_size_; i++) {
+        input_index[i] = (i < input_size_ / 4 ? i / ((simd_width_ + 1)/ 2) :
+                          (i < input_size_ / 2 ? i * 2 :
+                           (i < input_size_* 3 / 4 ? c : i)));
+    }
+
+    multicore::gen_constraint(input_index, output_constraint);
+
+    if (simd_width_ != 1) {
+        EXPECT_EQ(input_size_ / 4, output_constraint.compartment_sizes[contiguous]);
+        EXPECT_EQ(input_size_ / 4, output_constraint.compartment_sizes[constant]);
+        EXPECT_EQ(input_size_ / 4, output_constraint.compartment_sizes[independent]);
+        EXPECT_EQ(input_size_ / 4, output_constraint.compartment_sizes[none]);
+    }
+    else {
+        EXPECT_EQ(input_size_, output_constraint.compartment_sizes[contiguous]);
+        EXPECT_EQ(0, output_constraint.compartment_sizes[constant]);
+        EXPECT_EQ(0, output_constraint.compartment_sizes[independent]);
+        EXPECT_EQ(0, output_constraint.compartment_sizes[none]);
+    }
+
+    for (unsigned i = 0; i < input_size_; i++) {
+        if (simd_width_ != 1) {
+            if (i < input_size_ / 4)
+                EXPECT_EQ(output_constraint.full_index_compartments[i + input_size_ / 2],
+                          input_index[i]);
+            else if (i < input_size_ / 2)
+                EXPECT_EQ(output_constraint.full_index_compartments[i],
+                          input_index[i]);
+            else if (i < input_size_ * 3 / 4)
+                EXPECT_EQ(output_constraint.full_index_compartments[i + input_size_ / 4],
+                          input_index[i]);
+            else
+                EXPECT_EQ(output_constraint.full_index_compartments[i - input_size_ * 3 / 4],
+                          input_index[i]);
+        }
+        else {
+            EXPECT_EQ(output_constraint.full_index_compartments[i],
+                      input_index[i]);
+        }
+    }
+}

--- a/tests/unit/test_partition_by_constraint.cpp
+++ b/tests/unit/test_partition_by_constraint.cpp
@@ -55,21 +55,20 @@ TEST(partition_by_constraint, partition_constant) {
 
     multicore::generate_index_constraint_partitions(input_index, output_constraint, input_size_);
 
+    EXPECT_EQ(0, output_constraint.independent.size());
+    EXPECT_EQ(0, output_constraint.none.size());
     if(simd_width_ != 1) {
         EXPECT_EQ(input_size_/simd_width_, output_constraint.constant.size());
         EXPECT_EQ(0, output_constraint.contiguous.size());
+
+        for (unsigned i = 0; i < input_size_ / simd_width_; i++)
+            EXPECT_EQ(expected_indices[i], output_constraint.constant[i]);
     }
     else {
         EXPECT_EQ(0, output_constraint.constant.size());
         EXPECT_EQ(input_size_/simd_width_, output_constraint.contiguous.size());
-    }
-    EXPECT_EQ(0, output_constraint.independent.size());
-    EXPECT_EQ(0, output_constraint.none.size());
 
-    for (unsigned i = 0; i < input_size_ / simd_width_; i++) {
-        if(simd_width_ != 1)
-            EXPECT_EQ(expected_indices[i], output_constraint.constant[i]);
-        else
+        for (unsigned i = 0; i < input_size_ / simd_width_; i++)
             EXPECT_EQ(expected_indices[i], output_constraint.contiguous[i]);
     }
 }
@@ -87,21 +86,20 @@ TEST(partition_by_constraint, partition_independent) {
 
     multicore::generate_index_constraint_partitions(input_index, output_constraint, input_size_);
 
+    EXPECT_EQ(0, output_constraint.constant.size());
+    EXPECT_EQ(0, output_constraint.none.size());
     if(simd_width_ != 1) {
         EXPECT_EQ(input_size_/simd_width_, output_constraint.independent.size());
         EXPECT_EQ(0, output_constraint.contiguous.size());
+
+        for (unsigned i = 0; i < input_size_ / simd_width_; i++)
+            EXPECT_EQ(expected_indices[i], output_constraint.independent[i]);
     }
     else {
         EXPECT_EQ(0, output_constraint.independent.size());
         EXPECT_EQ(input_size_/simd_width_, output_constraint.contiguous.size());
-    }
-    EXPECT_EQ(0, output_constraint.constant.size());
-    EXPECT_EQ(0, output_constraint.none.size());
 
-    for (unsigned i = 0; i < input_size_ / simd_width_; i++) {
-        if(simd_width_ != 1)
-            EXPECT_EQ(expected_indices[i], output_constraint.independent[i]);
-        else
+        for (unsigned i = 0; i < input_size_ / simd_width_; i++)
             EXPECT_EQ(expected_indices[i], output_constraint.contiguous[i]);
     }
 }
@@ -119,21 +117,20 @@ TEST(partition_by_constraint, partition_serial) {
 
     multicore::generate_index_constraint_partitions(input_index, output_constraint, input_size_);
 
+    EXPECT_EQ(0, output_constraint.independent.size());
+    EXPECT_EQ(0, output_constraint.constant.size());
     if(simd_width_ != 1) {
         EXPECT_EQ(input_size_/simd_width_, output_constraint.none.size());
         EXPECT_EQ(0, output_constraint.contiguous.size());
+
+        for (unsigned i = 0; i < input_size_ / simd_width_; i++)
+            EXPECT_EQ(expected_indices[i], output_constraint.none[i]);
     }
     else {
         EXPECT_EQ(0, output_constraint.none.size());
         EXPECT_EQ(input_size_/simd_width_, output_constraint.contiguous.size());
-    }
-    EXPECT_EQ(0, output_constraint.independent.size());
-    EXPECT_EQ(0, output_constraint.constant.size());
 
-    for (unsigned i = 0; i < input_size_ / simd_width_; i++) {
-        if(simd_width_ != 1)
-            EXPECT_EQ(expected_indices[i], output_constraint.none[i]);
-        else
+        for (unsigned i = 0; i < input_size_ / simd_width_; i++)
             EXPECT_EQ(expected_indices[i], output_constraint.contiguous[i]);
     }
 }
@@ -168,15 +165,7 @@ TEST(partition_by_constraint, partition_random) {
         EXPECT_EQ(input_size_ / 4 / simd_width_, output_constraint.constant.size());
         EXPECT_EQ(input_size_ / 4 / simd_width_, output_constraint.independent.size());
         EXPECT_EQ(input_size_ / 4 / simd_width_, output_constraint.none.size());
-    }
-    else {
-        EXPECT_EQ(input_size_ / simd_width_, output_constraint.contiguous.size());
-        EXPECT_EQ(0, output_constraint.constant.size());
-        EXPECT_EQ(0, output_constraint.independent.size());
-        EXPECT_EQ(0, output_constraint.none.size());
-    }
 
-    if (simd_width_ != 1) {
         for (unsigned i = 0; i < input_size_ / simd_width_ / 4; i++) {
             EXPECT_EQ(expected_indices_contiguous[i], output_constraint.contiguous[i]);
             EXPECT_EQ(expected_indices_constant[i], output_constraint.constant[i]);
@@ -185,8 +174,14 @@ TEST(partition_by_constraint, partition_random) {
         }
     }
     else {
+        EXPECT_EQ(input_size_ / simd_width_, output_constraint.contiguous.size());
+        EXPECT_EQ(0, output_constraint.constant.size());
+        EXPECT_EQ(0, output_constraint.independent.size());
+        EXPECT_EQ(0, output_constraint.none.size());
+
         for (unsigned i = 0; i < input_size_ / simd_width_; i++) {
             EXPECT_EQ(i, output_constraint.contiguous[i]);
         }
     }
+
 }

--- a/tests/unit/test_partition_by_constraint.cpp
+++ b/tests/unit/test_partition_by_constraint.cpp
@@ -18,170 +18,136 @@ const int input_size_ = 1024;
 
 TEST(partition_by_constraint, partition_contiguous) {
     iarray input_index(input_size_);
-    iarray expected_indices;
-    multicore::constraint_partitions output_constraint;
+    iarray expected;
+    multicore::constraint_partition output;
 
 
     for (unsigned i = 0; i < input_size_; i++) {
         input_index[i] = i;
         if(i % simd_width_ == 0)
-            expected_indices.push_back(i);
+            expected.push_back(i);
     }
 
-    multicore::generate_index_constraint_partitions(input_index, output_constraint, input_size_);
+    output = multicore::make_constraint_partition(input_index, input_size_, simd_width_);
 
-    EXPECT_EQ(input_size_/simd_width_, output_constraint.contiguous.size());
-    EXPECT_EQ(0, output_constraint.constant.size());
-    EXPECT_EQ(0, output_constraint.independent.size());
-    EXPECT_EQ(0, output_constraint.none.size());
-
-    for (unsigned i = 0; i < input_size_ / simd_width_; i++) {
-        EXPECT_EQ(expected_indices[i], output_constraint.contiguous[i]);
-    }
+    EXPECT_EQ(0, output.independent.size());
+    EXPECT_EQ(0, output.none.size());
+    EXPECT_EQ(0, output.constant.size());
+    EXPECT_EQ(expected, output.contiguous);
 }
 
 TEST(partition_by_constraint, partition_constant) {
     iarray input_index(input_size_);
-    iarray expected_indices;
-    multicore::constraint_partitions output_constraint;
+    iarray expected;
+    multicore::constraint_partition output;
 
     const int c = 5;
 
     for (unsigned i = 0; i < input_size_; i++) {
         input_index[i] = c;
         if(i % simd_width_ == 0)
-            expected_indices.push_back(i);
+            expected.push_back(i);
     }
 
-    multicore::generate_index_constraint_partitions(input_index, output_constraint, input_size_);
+    output = multicore::make_constraint_partition(input_index, input_size_, simd_width_);
 
-    EXPECT_EQ(0, output_constraint.independent.size());
-    EXPECT_EQ(0, output_constraint.none.size());
+    EXPECT_EQ(0, output.independent.size());
+    EXPECT_EQ(0, output.none.size());
     if(simd_width_ != 1) {
-        EXPECT_EQ(input_size_/simd_width_, output_constraint.constant.size());
-        EXPECT_EQ(0, output_constraint.contiguous.size());
-
-        for (unsigned i = 0; i < input_size_ / simd_width_; i++)
-            EXPECT_EQ(expected_indices[i], output_constraint.constant[i]);
+        EXPECT_EQ(0, output.contiguous.size());
+        EXPECT_EQ(expected, output.constant);
     }
     else {
-        EXPECT_EQ(0, output_constraint.constant.size());
-        EXPECT_EQ(input_size_/simd_width_, output_constraint.contiguous.size());
-
-        for (unsigned i = 0; i < input_size_ / simd_width_; i++)
-            EXPECT_EQ(expected_indices[i], output_constraint.contiguous[i]);
+        EXPECT_EQ(0, output.constant.size());
+        EXPECT_EQ(expected, output.contiguous);
     }
 }
 
 TEST(partition_by_constraint, partition_independent) {
     iarray input_index(input_size_);
-    iarray expected_indices;
-    multicore::constraint_partitions output_constraint;
+    iarray expected;
+    multicore::constraint_partition output;
 
     for (unsigned i = 0; i < input_size_; i++) {
         input_index[i] = i * 2;
         if(i % simd_width_ == 0)
-            expected_indices.push_back(i);
+            expected.push_back(i);
     }
 
-    multicore::generate_index_constraint_partitions(input_index, output_constraint, input_size_);
+    output = multicore::make_constraint_partition(input_index, input_size_, simd_width_);
 
-    EXPECT_EQ(0, output_constraint.constant.size());
-    EXPECT_EQ(0, output_constraint.none.size());
+    EXPECT_EQ(0, output.constant.size());
+    EXPECT_EQ(0, output.none.size());
     if(simd_width_ != 1) {
-        EXPECT_EQ(input_size_/simd_width_, output_constraint.independent.size());
-        EXPECT_EQ(0, output_constraint.contiguous.size());
-
-        for (unsigned i = 0; i < input_size_ / simd_width_; i++)
-            EXPECT_EQ(expected_indices[i], output_constraint.independent[i]);
+        EXPECT_EQ(0, output.contiguous.size());
+        EXPECT_EQ(expected, output.independent);
     }
     else {
-        EXPECT_EQ(0, output_constraint.independent.size());
-        EXPECT_EQ(input_size_/simd_width_, output_constraint.contiguous.size());
-
-        for (unsigned i = 0; i < input_size_ / simd_width_; i++)
-            EXPECT_EQ(expected_indices[i], output_constraint.contiguous[i]);
+        EXPECT_EQ(0, output.independent.size());
+        EXPECT_EQ(expected, output.contiguous);
     }
 }
 
-TEST(partition_by_constraint, partition_serial) {
+TEST(partition_by_constraint, partition_none) {
     iarray input_index(input_size_);
-    iarray expected_indices;
-    multicore::constraint_partitions output_constraint;
+    iarray expected;
+    multicore::constraint_partition output;
 
     for (unsigned i = 0; i < input_size_; i++) {
         input_index[i] = i / ((simd_width_ + 1)/ 2);
         if(i % simd_width_ == 0)
-            expected_indices.push_back(i);
+            expected.push_back(i);
     }
 
-    multicore::generate_index_constraint_partitions(input_index, output_constraint, input_size_);
+    output = multicore::make_constraint_partition(input_index, input_size_, simd_width_);
 
-    EXPECT_EQ(0, output_constraint.independent.size());
-    EXPECT_EQ(0, output_constraint.constant.size());
+    EXPECT_EQ(0, output.independent.size());
+    EXPECT_EQ(0, output.constant.size());
     if(simd_width_ != 1) {
-        EXPECT_EQ(input_size_/simd_width_, output_constraint.none.size());
-        EXPECT_EQ(0, output_constraint.contiguous.size());
-
-        for (unsigned i = 0; i < input_size_ / simd_width_; i++)
-            EXPECT_EQ(expected_indices[i], output_constraint.none[i]);
+        EXPECT_EQ(0, output.contiguous.size());
+        EXPECT_EQ(expected, output.none);
     }
     else {
-        EXPECT_EQ(0, output_constraint.none.size());
-        EXPECT_EQ(input_size_/simd_width_, output_constraint.contiguous.size());
-
-        for (unsigned i = 0; i < input_size_ / simd_width_; i++)
-            EXPECT_EQ(expected_indices[i], output_constraint.contiguous[i]);
+        EXPECT_EQ(0, output.none.size());
+        EXPECT_EQ(expected, output.contiguous);
     }
 }
 
 TEST(partition_by_constraint, partition_random) {
     iarray input_index(input_size_);
-    iarray expected_indices_contiguous, expected_indices_constant,
-            expected_indices_independent, expected_indices_serial;
-    multicore::constraint_partitions output_constraint;
+    iarray expected_contiguous, expected_constant,
+            expected_independent, expected_none, expected_simd_1;
+    multicore::constraint_partition output;
 
 
     const int c = 5;
-//shuffle here
     for (unsigned i = 0; i < input_size_; i++) {
-        input_index[i] = (i < input_size_ / 4 ? i / ((simd_width_ + 1)/ 2) :
-                          (i < input_size_ / 2 ? i * 2 :
-                           (i < input_size_* 3 / 4 ? c : i)));
+        input_index[i] = i<input_size_/4   ? i/((simd_width_ + 1)/ 2):
+                         i<input_size_/2   ? i*2:
+                         i<input_size_*3/4 ? c:
+                         i;
         if (i < input_size_ / 4 && i % simd_width_ == 0)
-            expected_indices_serial.push_back(i);
+            expected_none.push_back(i);
         else if (i < input_size_ / 2 && i % simd_width_ == 0)
-            expected_indices_independent.push_back(i);
+            expected_independent.push_back(i);
         else if (i < input_size_* 3/ 4 && i % simd_width_ == 0)
-            expected_indices_constant.push_back(i);
+            expected_constant.push_back(i);
         else if (i % simd_width_ == 0)
-            expected_indices_contiguous.push_back(i);
+            expected_contiguous.push_back(i);
+        expected_simd_1.push_back(i);
+
     }
 
-    multicore::generate_index_constraint_partitions(input_index, output_constraint, input_size_);
+    output = multicore::make_constraint_partition(input_index, input_size_, simd_width_);
 
     if (simd_width_ != 1) {
-        EXPECT_EQ(input_size_ / 4 / simd_width_, output_constraint.contiguous.size());
-        EXPECT_EQ(input_size_ / 4 / simd_width_, output_constraint.constant.size());
-        EXPECT_EQ(input_size_ / 4 / simd_width_, output_constraint.independent.size());
-        EXPECT_EQ(input_size_ / 4 / simd_width_, output_constraint.none.size());
-
-        for (unsigned i = 0; i < input_size_ / simd_width_ / 4; i++) {
-            EXPECT_EQ(expected_indices_contiguous[i], output_constraint.contiguous[i]);
-            EXPECT_EQ(expected_indices_constant[i], output_constraint.constant[i]);
-            EXPECT_EQ(expected_indices_independent[i], output_constraint.independent[i]);
-            EXPECT_EQ(expected_indices_serial[i], output_constraint.none[i]);
-        }
+        EXPECT_EQ(expected_contiguous, output.contiguous);
+        EXPECT_EQ(expected_constant, output.constant);
+        EXPECT_EQ(expected_independent, output.independent);
+        EXPECT_EQ(expected_none, output.none);
     }
     else {
-        EXPECT_EQ(input_size_ / simd_width_, output_constraint.contiguous.size());
-        EXPECT_EQ(0, output_constraint.constant.size());
-        EXPECT_EQ(0, output_constraint.independent.size());
-        EXPECT_EQ(0, output_constraint.none.size());
-
-        for (unsigned i = 0; i < input_size_ / simd_width_; i++) {
-            EXPECT_EQ(i, output_constraint.contiguous[i]);
-        }
+        EXPECT_EQ(expected_simd_1, output.contiguous);
     }
 
 }

--- a/tests/unit/test_partition_by_constraint.cpp
+++ b/tests/unit/test_partition_by_constraint.cpp
@@ -28,15 +28,15 @@ TEST(partition_by_constraint, partition_contiguous) {
             expected_indices.push_back(i);
     }
 
-    multicore::gen_constraint(input_index, output_constraint, input_size_);
+    multicore::generate_index_constraint_partitions(input_index, output_constraint, input_size_);
 
-    EXPECT_EQ(input_size_/simd_width_, output_constraint.contiguous_indices.size());
-    EXPECT_EQ(0, output_constraint.constant_indices.size());
-    EXPECT_EQ(0, output_constraint.independent_indices.size());
-    EXPECT_EQ(0, output_constraint.serialized_indices.size());
+    EXPECT_EQ(input_size_/simd_width_, output_constraint.contiguous.size());
+    EXPECT_EQ(0, output_constraint.constant.size());
+    EXPECT_EQ(0, output_constraint.independent.size());
+    EXPECT_EQ(0, output_constraint.none.size());
 
     for (unsigned i = 0; i < input_size_ / simd_width_; i++) {
-        EXPECT_EQ(expected_indices[i], output_constraint.contiguous_indices[i]);
+        EXPECT_EQ(expected_indices[i], output_constraint.contiguous[i]);
     }
 }
 
@@ -53,24 +53,24 @@ TEST(partition_by_constraint, partition_constant) {
             expected_indices.push_back(i);
     }
 
-    multicore::gen_constraint(input_index, output_constraint, input_size_);
+    multicore::generate_index_constraint_partitions(input_index, output_constraint, input_size_);
 
     if(simd_width_ != 1) {
-        EXPECT_EQ(input_size_/simd_width_, output_constraint.constant_indices.size());
-        EXPECT_EQ(0, output_constraint.contiguous_indices.size());
+        EXPECT_EQ(input_size_/simd_width_, output_constraint.constant.size());
+        EXPECT_EQ(0, output_constraint.contiguous.size());
     }
     else {
-        EXPECT_EQ(0, output_constraint.constant_indices.size());
-        EXPECT_EQ(input_size_/simd_width_, output_constraint.contiguous_indices.size());
+        EXPECT_EQ(0, output_constraint.constant.size());
+        EXPECT_EQ(input_size_/simd_width_, output_constraint.contiguous.size());
     }
-    EXPECT_EQ(0, output_constraint.independent_indices.size());
-    EXPECT_EQ(0, output_constraint.serialized_indices.size());
+    EXPECT_EQ(0, output_constraint.independent.size());
+    EXPECT_EQ(0, output_constraint.none.size());
 
     for (unsigned i = 0; i < input_size_ / simd_width_; i++) {
         if(simd_width_ != 1)
-            EXPECT_EQ(expected_indices[i], output_constraint.constant_indices[i]);
+            EXPECT_EQ(expected_indices[i], output_constraint.constant[i]);
         else
-            EXPECT_EQ(expected_indices[i], output_constraint.contiguous_indices[i]);
+            EXPECT_EQ(expected_indices[i], output_constraint.contiguous[i]);
     }
 }
 
@@ -85,24 +85,24 @@ TEST(partition_by_constraint, partition_independent) {
             expected_indices.push_back(i);
     }
 
-    multicore::gen_constraint(input_index, output_constraint, input_size_);
+    multicore::generate_index_constraint_partitions(input_index, output_constraint, input_size_);
 
     if(simd_width_ != 1) {
-        EXPECT_EQ(input_size_/simd_width_, output_constraint.independent_indices.size());
-        EXPECT_EQ(0, output_constraint.contiguous_indices.size());
+        EXPECT_EQ(input_size_/simd_width_, output_constraint.independent.size());
+        EXPECT_EQ(0, output_constraint.contiguous.size());
     }
     else {
-        EXPECT_EQ(0, output_constraint.independent_indices.size());
-        EXPECT_EQ(input_size_/simd_width_, output_constraint.contiguous_indices.size());
+        EXPECT_EQ(0, output_constraint.independent.size());
+        EXPECT_EQ(input_size_/simd_width_, output_constraint.contiguous.size());
     }
-    EXPECT_EQ(0, output_constraint.constant_indices.size());
-    EXPECT_EQ(0, output_constraint.serialized_indices.size());
+    EXPECT_EQ(0, output_constraint.constant.size());
+    EXPECT_EQ(0, output_constraint.none.size());
 
     for (unsigned i = 0; i < input_size_ / simd_width_; i++) {
         if(simd_width_ != 1)
-            EXPECT_EQ(expected_indices[i], output_constraint.independent_indices[i]);
+            EXPECT_EQ(expected_indices[i], output_constraint.independent[i]);
         else
-            EXPECT_EQ(expected_indices[i], output_constraint.contiguous_indices[i]);
+            EXPECT_EQ(expected_indices[i], output_constraint.contiguous[i]);
     }
 }
 
@@ -117,24 +117,24 @@ TEST(partition_by_constraint, partition_serial) {
             expected_indices.push_back(i);
     }
 
-    multicore::gen_constraint(input_index, output_constraint, input_size_);
+    multicore::generate_index_constraint_partitions(input_index, output_constraint, input_size_);
 
     if(simd_width_ != 1) {
-        EXPECT_EQ(input_size_/simd_width_, output_constraint.serialized_indices.size());
-        EXPECT_EQ(0, output_constraint.contiguous_indices.size());
+        EXPECT_EQ(input_size_/simd_width_, output_constraint.none.size());
+        EXPECT_EQ(0, output_constraint.contiguous.size());
     }
     else {
-        EXPECT_EQ(0, output_constraint.serialized_indices.size());
-        EXPECT_EQ(input_size_/simd_width_, output_constraint.contiguous_indices.size());
+        EXPECT_EQ(0, output_constraint.none.size());
+        EXPECT_EQ(input_size_/simd_width_, output_constraint.contiguous.size());
     }
-    EXPECT_EQ(0, output_constraint.independent_indices.size());
-    EXPECT_EQ(0, output_constraint.constant_indices.size());
+    EXPECT_EQ(0, output_constraint.independent.size());
+    EXPECT_EQ(0, output_constraint.constant.size());
 
     for (unsigned i = 0; i < input_size_ / simd_width_; i++) {
         if(simd_width_ != 1)
-            EXPECT_EQ(expected_indices[i], output_constraint.serialized_indices[i]);
+            EXPECT_EQ(expected_indices[i], output_constraint.none[i]);
         else
-            EXPECT_EQ(expected_indices[i], output_constraint.contiguous_indices[i]);
+            EXPECT_EQ(expected_indices[i], output_constraint.contiguous[i]);
     }
 }
 
@@ -161,86 +161,32 @@ TEST(partition_by_constraint, partition_random) {
             expected_indices_contiguous.push_back(i);
     }
 
-    multicore::gen_constraint(input_index, output_constraint, input_size_);
+    multicore::generate_index_constraint_partitions(input_index, output_constraint, input_size_);
 
     if (simd_width_ != 1) {
-        EXPECT_EQ(input_size_ / 4 / simd_width_, output_constraint.contiguous_indices.size());
-        EXPECT_EQ(input_size_ / 4 / simd_width_, output_constraint.constant_indices.size());
-        EXPECT_EQ(input_size_ / 4 / simd_width_, output_constraint.independent_indices.size());
-        EXPECT_EQ(input_size_ / 4 / simd_width_, output_constraint.serialized_indices.size());
+        EXPECT_EQ(input_size_ / 4 / simd_width_, output_constraint.contiguous.size());
+        EXPECT_EQ(input_size_ / 4 / simd_width_, output_constraint.constant.size());
+        EXPECT_EQ(input_size_ / 4 / simd_width_, output_constraint.independent.size());
+        EXPECT_EQ(input_size_ / 4 / simd_width_, output_constraint.none.size());
     }
     else {
-        EXPECT_EQ(input_size_ / simd_width_, output_constraint.contiguous_indices.size());
-        EXPECT_EQ(0, output_constraint.constant_indices.size());
-        EXPECT_EQ(0, output_constraint.independent_indices.size());
-        EXPECT_EQ(0, output_constraint.serialized_indices.size());
+        EXPECT_EQ(input_size_ / simd_width_, output_constraint.contiguous.size());
+        EXPECT_EQ(0, output_constraint.constant.size());
+        EXPECT_EQ(0, output_constraint.independent.size());
+        EXPECT_EQ(0, output_constraint.none.size());
     }
 
     if (simd_width_ != 1) {
         for (unsigned i = 0; i < input_size_ / simd_width_ / 4; i++) {
-            EXPECT_EQ(expected_indices_contiguous[i], output_constraint.contiguous_indices[i]);
-            EXPECT_EQ(expected_indices_constant[i], output_constraint.constant_indices[i]);
-            EXPECT_EQ(expected_indices_independent[i], output_constraint.independent_indices[i]);
-            EXPECT_EQ(expected_indices_serial[i], output_constraint.serialized_indices[i]);
+            EXPECT_EQ(expected_indices_contiguous[i], output_constraint.contiguous[i]);
+            EXPECT_EQ(expected_indices_constant[i], output_constraint.constant[i]);
+            EXPECT_EQ(expected_indices_independent[i], output_constraint.independent[i]);
+            EXPECT_EQ(expected_indices_serial[i], output_constraint.none[i]);
         }
     }
     else {
         for (unsigned i = 0; i < input_size_ / simd_width_; i++) {
-            EXPECT_EQ(i, output_constraint.contiguous_indices[i]);
-        }
-    }
-}
-
-TEST(partition_by_constraint, partition_subvector_constraint_categorization) {
-    iarray input_index(input_size_);
-    multicore::constraint_partitions output_constraint;
-
-    if(simd_width_ == 4) {
-        {
-            iarray input_index_constant0;
-            for (unsigned i = 0; i < simd_width_; i++) {
-                input_index_constant0.push_back(0);
-            }
-            EXPECT_EQ(multicore::get_subvector_index_constraint(input_index_constant0, 0), index_constraint::constant);
-        }
-
-        {
-            iarray input_index_contiguous0;
-            for (unsigned i = 0; i < simd_width_; i++) {
-                input_index_contiguous0.push_back(i);
-            }
-            EXPECT_EQ(multicore::get_subvector_index_constraint(input_index_contiguous0, 0),
-                      index_constraint::contiguous);
-        }
-
-        {
-            iarray input_index_independent0;
-            for (unsigned i = 0; i < simd_width_; i++) {
-                input_index_independent0.push_back(i * 2);
-            }
-            EXPECT_EQ(multicore::get_subvector_index_constraint(input_index_independent0, 0),
-                      index_constraint::independent);
-        }
-
-        {
-            iarray input_index_serial0;
-            for (unsigned i = 0; i < simd_width_; i++) {
-                input_index_serial0.push_back(i / 2);
-            }
-            EXPECT_EQ(multicore::get_subvector_index_constraint(input_index_serial0, 0), index_constraint::none);
-        }
-
-        {
-            iarray input_index_serial1 = iarray{1, 2, 2, 4};
-            EXPECT_EQ(multicore::get_subvector_index_constraint(input_index_serial1, 0), index_constraint::none);
-        }
-
-
-        {
-            iarray input_index_independent1 = iarray{0, 2, 656, 900};
-            EXPECT_EQ(multicore::get_subvector_index_constraint(input_index_independent1, 0),
-                      index_constraint::independent);
-
+            EXPECT_EQ(i, output_constraint.contiguous[i]);
         }
     }
 }

--- a/tests/unit/test_simd.cpp
+++ b/tests/unit/test_simd.cpp
@@ -8,9 +8,11 @@
 #include <simd/simd.hpp>
 #include <simd/avx.hpp>
 
+#include <common_types.hpp>
 #include "common.hpp"
 
 using namespace arb::simd;
+using index_constraint = arb::index_constraint;
 
 namespace {
     // Use different distributions in `fill_random`, based on the value type in question:

--- a/tests/unit/test_simd.cpp
+++ b/tests/unit/test_simd.cpp
@@ -12,7 +12,7 @@
 #include "common.hpp"
 
 using namespace arb::simd;
-using index_constraint = arb::index_constraint;
+using index_constraint = arb::simd::index_constraint;
 
 namespace {
     // Use different distributions in `fill_random`, based on the value type in question:


### PR DESCRIPTION
Changes have been made to the simd implementation of mechansim functions: 

- The node_index array (array of indices that specifies for each mechanism the CVs where it is present), is now partitioned into 4 arrays according to the constraint on each simd_vector in node_index:
    1. contiguous array: contains the indices of all simd_vectors in node_index where the elements in simd_vector are contiguous
    2. constant array: contains the indices of all simd_vectors in node_index where the elements in simd_vector are identical
    3. independent array: contains the indices of all simd_vectors in node_index where the elements in simd_vector are independent (no repetitions) but not contiguous 
    4. none array: contains the indices of all simd_vectors in node_index where the none of the above constraints apply

    When mechanism functions are executed, they loop over each of the 4 arrays separately. This allows for optimizations in every category. 

- The modcc compiler was modified to generate code for the previous changes, including the optimizations per constraint:
    1. contiguous array: we use vector load/store and vector arithmetic. 
    2. constant array: we load only one element and broadcast it into a simd_vector; we use vector arithmetic; we reduce the result; we store one element.   
    3. indepndent array: we use vector scatter/gather and vector arithmetic. 
    4. none array: we cannot operate on the simd_vector in parallel, we loop over the elements to read, perform arithmetic and write back 

- Added a mechanism benchmark for pas, hh and expsyn

- Moved/modified some functions in simd.hpp to ensure that the correct implementation of a function is being called. 
 
