### PR TITLE
Bugfix: a[i]=b[i] for memory::device_vector

### DIFF
--- a/arbor/memory/device_coordinator.hpp
+++ b/arbor/memory/device_coordinator.hpp
@@ -80,6 +80,10 @@ public:
         return *this;
     }
 
+    device_reference& operator=(const device_reference& ref) {
+        cuda_memcpy_d2d(pointer_, ref.pointer_, sizeof(T));
+    }
+
     operator T() const {
         T tmp;
         cuda_memcpy_d2h(&tmp, pointer_, sizeof(T));


### PR DESCRIPTION
* Perform device-to-device copy when device_reference is assigned a device_reference.

Fixes #286.