### PR TITLE
Remove `memory::array` from `arb::tree`

### DIFF
--- a/arbor/tree.hpp
+++ b/arbor/tree.hpp
@@ -103,7 +103,7 @@ public:
     auto children(size_type i) const {
         const auto b = child_index_[i];
         const auto e = child_index_[i+1];
-        return util::make_range(&children_[b], &children_[e]);
+        return util::subrange_view(children_, b, e);
     }
 
     /// return the list of parents

--- a/test/unit/test_tree.cpp
+++ b/test/unit/test_tree.cpp
@@ -164,6 +164,13 @@ TEST(tree, from_segment_index) {
         EXPECT_EQ(tree.num_children(4), 2u);
         EXPECT_EQ(tree.num_children(5), 0u);
         EXPECT_EQ(tree.num_children(6), 0u);
+
+        EXPECT_EQ(tree.children(0)[0], 1u);
+        EXPECT_EQ(tree.children(0)[1], 2u);
+        EXPECT_EQ(tree.children(1)[0], 3u);
+        EXPECT_EQ(tree.children(1)[1], 4u);
+        EXPECT_EQ(tree.children(4)[0], 5u);
+        EXPECT_EQ(tree.children(4)[1], 6u);
     }
 }
 


### PR DESCRIPTION
This small refactor simplifies the interface and implementation of the `tree` type.
* use `std::vector` instead of `memory::array` for internal storage in `arb::tree`
* return a `util::range` intstead of a view for `tree::children(int)`
* remove unused functionality for changing the root of a tree.