### PR TITLE
Split multi_event_stream.cu implementation.

### DIFF
--- a/arbor/CMakeLists.txt
+++ b/arbor/CMakeLists.txt
@@ -59,6 +59,7 @@ if(ARB_WITH_CUDA)
         backends/gpu/matrix_assemble.cu
         backends/gpu/matrix_interleave.cu
         backends/gpu/matrix_solve.cu
+        backends/gpu/multi_event_stream.cpp
         backends/gpu/multi_event_stream.cu
         backends/gpu/shared_state.cu
         backends/gpu/stimulus.cu

--- a/arbor/backends/gpu/multi_event_stream.cpp
+++ b/arbor/backends/gpu/multi_event_stream.cpp
@@ -1,0 +1,17 @@
+#include <arbor/common_types.hpp>
+
+#include "backends/gpu/multi_event_stream.hpp"
+#include "memory/memory.hpp"
+
+namespace arb {
+namespace gpu {
+
+void multi_event_stream_base::clear() {
+    memory::fill(span_begin_, 0u);
+    memory::fill(span_end_, 0u);
+    memory::fill(mark_, 0u);
+    n_nonempty_stream_[0] = 0;
+}
+
+} // namespace gpu
+} // namespace arb

--- a/arbor/backends/gpu/multi_event_stream.cu
+++ b/arbor/backends/gpu/multi_event_stream.cu
@@ -2,10 +2,6 @@
 
 #include "backends/event.hpp"
 #include "backends/gpu/multi_event_stream.hpp"
-#include "memory/array.hpp"
-#include "memory/copy.hpp"
-#include "util/rangeutil.hpp"
-
 #include "cuda_common.hpp"
 
 namespace arb {
@@ -90,17 +86,10 @@ namespace kernels {
     }
 } // namespace kernels
 
-void multi_event_stream_base::clear() {
-    memory::fill(span_begin_, 0u);
-    memory::fill(span_end_, 0u);
-    memory::fill(mark_, 0u);
-    n_nonempty_stream_[0] = 0;
-}
-
 // Designate for processing events `ev` at head of each event stream `i`
 // until `event_time(ev)` > `t_until[i]`.
 void multi_event_stream_base::mark_until_after(const_view t_until) {
-    arb_assert(n_streams()==util::size(t_until));
+    arb_assert(n_streams()==t_until.size());
 
     constexpr int block_dim = 128;
 
@@ -113,7 +102,7 @@ void multi_event_stream_base::mark_until_after(const_view t_until) {
 // Designate for processing events `ev` at head of each event stream `i`
 // while `t_until[i]` > `event_time(ev)`.
 void multi_event_stream_base::mark_until(const_view t_until) {
-    arb_assert(n_streams()==util::size(t_until));
+    arb_assert(n_streams()==t_until.size());
     constexpr int block_dim = 128;
 
     unsigned n = n_stream_;

--- a/arbor/backends/gpu/multi_event_stream.hpp
+++ b/arbor/backends/gpu/multi_event_stream.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-// Indexed collection of pop-only event queues --- multicore back-end implementation.
+// Indexed collection of pop-only event queues --- CUDA back-end implementation.
 
 #include <arbor/arbexcept.hpp>
 #include <arbor/common_types.hpp>


### PR DESCRIPTION
* Remove dependency on memory library and range utils from `multi_event_stream.cu` source.

Fixes #545