### PR TITLE
Bugfix/build osx macports

### DIFF
--- a/arbor/communication/mpi.hpp
+++ b/arbor/communication/mpi.hpp
@@ -48,15 +48,19 @@ struct mpi_traits<T> {  \
     constexpr static bool is_mpi_native_type() { return true; } \
 };
 
-MAKE_TRAITS(double, MPI_DOUBLE)
-MAKE_TRAITS(float,  MPI_FLOAT)
-MAKE_TRAITS(int,    MPI_INT)
-MAKE_TRAITS(long int, MPI_LONG)
-MAKE_TRAITS(char,   MPI_CHAR)
-MAKE_TRAITS(unsigned int, MPI_UNSIGNED)
-MAKE_TRAITS(size_t, MPI_UNSIGNED_LONG)
-static_assert(sizeof(size_t)==sizeof(unsigned long),
-              "size_t and unsigned long are not equivalent");
+MAKE_TRAITS(float,              MPI_FLOAT)
+MAKE_TRAITS(double,             MPI_DOUBLE)
+MAKE_TRAITS(char,               MPI_CHAR)
+MAKE_TRAITS(int,                MPI_INT)
+MAKE_TRAITS(unsigned,           MPI_UNSIGNED)
+MAKE_TRAITS(long,               MPI_LONG)
+MAKE_TRAITS(unsigned long,      MPI_UNSIGNED_LONG)
+MAKE_TRAITS(long long,          MPI_LONG_LONG)
+MAKE_TRAITS(unsigned long long, MPI_UNSIGNED_LONG_LONG)
+
+static_assert(std::is_same<std::size_t, unsigned long>::value ||
+              std::is_same<std::size_t, unsigned long long>::value,
+              "size_t is not the same as unsigned long or unsigned long long");
 
 // Gather individual values of type T from each rank into a std::vector on
 // the root rank.

--- a/aux/glob.cpp
+++ b/aux/glob.cpp
@@ -1,6 +1,6 @@
 // POSIX headers
 extern "C" {
-#define _POSIX_C_SOURCE 2
+#define _POSIX_C_SOURCE 200809L
 #include <glob.h>
 }
 

--- a/include/arbor/distributed_context.hpp
+++ b/include/arbor/distributed_context.hpp
@@ -27,7 +27,7 @@ namespace arb {
     T sum(T value) const override { return wrapped.sum(value); }\
     std::vector<T> gather(T value, int root) const override { return wrapped.gather(value, root); }
 
-#define ARB_COLLECTIVE_TYPES_ float, double, int, std::uint32_t, std::uint64_t
+#define ARB_COLLECTIVE_TYPES_ float, double, int, unsigned, long, unsigned long, long long, unsigned long long
 
 // Defines the concept/interface for a distributed communication context.
 //


### PR DESCRIPTION
Two MacPorts/gcc7 issues:
1. `std::uint64_t` is `unsigned long long` on OS X, breaking an assumption about `size_t` in the `distributed_context` interface.
2. Problems with missing errno defines in the standard library headers.

With MacPorts gcc7, the installed `c++config.h` defines `_GLIBCXX_HAVE_EOWNERDEAD` and `_GLIBCXX_HAVE_ENOTRECOVERABLE`, but the corresponding errno defines are not provided by
`sys/errno.h` unless `__DARWIN_C_SOURCE`, which takes its value from `_POSIX_C_SOURCE` if defined, is greater than or equal to 200809L. Technically a MacPorts configuration bug? but easily worked around.

* Use basic integral types for communication collectives interfaces.
* Define `_POSIX_C_SOURCE` to be 200809L for `glob.cpp`.

Fixes #562.