### PR TITLE
Work-around for gcc version < 8.2 versus std::fma

### DIFF
--- a/cmake/CompilerOptions.cmake
+++ b/cmake/CompilerOptions.cmake
@@ -81,12 +81,6 @@ function(set_arch_target optvar arch)
 
         if(target_model MATCHES "x86" OR target_model MATCHES "amd64")
             set(arch_opt "-march=${arch}")
-
-            # Disable tree optimizer in gcc pre-version 8.2 on x86, owing to compiler bug.
-            # (See: arbor issue #568, gcc issue #87046.)
-            if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8.2.o)
-                list(APPEND arch_opt "-fno-tree-vectorize")
-            endif()
         else()
             set(arch_opt "-mcpu=${arch}")
         endif()

--- a/cmake/CompilerOptions.cmake
+++ b/cmake/CompilerOptions.cmake
@@ -81,6 +81,12 @@ function(set_arch_target optvar arch)
 
         if(target_model MATCHES "x86" OR target_model MATCHES "amd64")
             set(arch_opt "-march=${arch}")
+
+            # Disable tree optimizer in gcc pre-version 8.2 on x86, owing to compiler bug.
+            # (See: arbor issue #568, gcc issue #87046.)
+            if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8.2.o)
+                list(APPEND arch_opt "-fno-tree-vectorize")
+            endif()
         else()
             set(arch_opt "-mcpu=${arch}")
         endif()

--- a/include/arbor/math.hpp
+++ b/include/arbor/math.hpp
@@ -5,6 +5,8 @@
 #include <type_traits>
 #include <utility>
 
+#include <arbor/util/compat.hpp>
+
 namespace arb {
 namespace math {
 
@@ -58,7 +60,7 @@ T constexpr area_sphere(T r) {
 // Linear interpolation by u in interval [a,b]: (1-u)*a + u*b.
 template <typename T, typename U>
 T constexpr lerp(T a, T b, U u) {
-    return std::fma(u, b, std::fma(-u, a, a));
+    return compat::fma(u, b, compat::fma(-u, a, a));
 }
 
 // Return -1, 0 or 1 according to sign of parameter.

--- a/include/arbor/math.hpp
+++ b/include/arbor/math.hpp
@@ -60,7 +60,7 @@ T constexpr area_sphere(T r) {
 // Linear interpolation by u in interval [a,b]: (1-u)*a + u*b.
 template <typename T, typename U>
 T constexpr lerp(T a, T b, U u) {
-    return compat::fma(u, b, compat::fma(-u, a, a));
+    return compat::fma(T(u), b, compat::fma(T(-u), a, a));
 }
 
 // Return -1, 0 or 1 according to sign of parameter.

--- a/include/arbor/simd/implbase.hpp
+++ b/include/arbor/simd/implbase.hpp
@@ -33,6 +33,8 @@
 #include <iterator>
 #include <type_traits>
 
+#include <arbor/util/compat.hpp>
+
 // Derived class I must at minimum provide:
 //
 // * specialization of simd_traits.
@@ -240,7 +242,7 @@ struct implbase {
         I::copy_to(w, c);
 
         for (unsigned i = 0; i<width; ++i) {
-            r[i] = std::fma(a[i], b[i], c[i]);
+            r[i] = compat::fma(a[i], b[i], c[i]);
         }
         return I::copy_from(r);
     }

--- a/include/arbor/util/compat.hpp
+++ b/include/arbor/util/compat.hpp
@@ -37,4 +37,14 @@ inline void compiler_barrier_if_icc_leq(unsigned ver) {
 #endif
 }
 
+// Work-around for bad vectorization of fma in gcc version < 8.2
+
+template <typename T>
+#if defined(__GNUC__) && (100*__GNUC__ + __GNUC_MINOR__ < 802)
+__attribute((optimize("no-tree-vectorize")))
+#endif
+inline auto fma(T a, T b, T c) {
+    return std::fma(a, b, c);
+}
+
 } // namespace compat

--- a/test/unit/test_simd.cpp
+++ b/test/unit/test_simd.cpp
@@ -7,6 +7,7 @@
 
 #include <arbor/simd/simd.hpp>
 #include <arbor/simd/avx.hpp>
+#include <arbor/util/compat.hpp>
 
 #include "common.hpp"
 
@@ -266,7 +267,7 @@ TYPED_TEST_P(simd_value, arithmetic) {
         for (unsigned i = 0; i<N; ++i) u_divide_v[i] = u[i]/v[i];
 
         scalar fma_u_v_w[N];
-        for (unsigned i = 0; i<N; ++i) fma_u_v_w[i] = std::fma(u[i],v[i],w[i]);
+        for (unsigned i = 0; i<N; ++i) fma_u_v_w[i] = compat::fma(u[i],v[i],w[i]);
 
         simd us(u), vs(v), ws(w);
 

--- a/test/validation/interpolate.hpp
+++ b/test/validation/interpolate.hpp
@@ -2,9 +2,11 @@
 
 #include <cmath>
 
+#include <arbor/util/compat.hpp>
+
 template <typename T, typename U>
 inline T lerp(T a, T b, U u) {
-    return std::fma(u, b, std::fma(-u, a, a));
+    return compat::fma(T(u), b, compat::fma(T(-u), a, a));
 }
 
 // Piece-wise linear interpolation across a sequence of points (u_i, x_i),


### PR DESCRIPTION
Use a `compat::fma` wrapper for `std::fma` to avoid a bug in the tree optimizer in GCC version < 8.2.

See: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=87046
Fixes #568.