### PR TITLE
Refine gcc version test for FMA work-around.

### DIFF
--- a/include/arbor/util/compat.hpp
+++ b/include/arbor/util/compat.hpp
@@ -37,10 +37,16 @@ inline void compiler_barrier_if_icc_leq(unsigned ver) {
 #endif
 }
 
-// Work-around for bad vectorization of fma in gcc version < 8.2
+// Work-around for bad vectorization of fma in gcc.
+// Bug fixed in 6.4.1, 7.3.1, 8.1.1 and 9.0: refer to gcc bug #85597,
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85597
 
 template <typename T>
-#if defined(__GNUC__) && (100*__GNUC__ + __GNUC_MINOR__ < 802)
+#if defined(__GNUC__) &&\
+    ( __GNUC__<6 ||\
+     (__GNUC__==6 && __GNUC_MINOR__*100 + __GNUC_PATCHLEVEL__ < 401) ||\
+     (__GNUC__==7 && __GNUC_MINOR__*100 + __GNUC_PATCHLEVEL__ < 301) ||\
+     (__GNUC__==8 && __GNUC_MINOR__*100 + __GNUC_PATCHLEVEL__ < 101))
 __attribute((optimize("no-tree-vectorize")))
 #endif
 inline auto fma(T a, T b, T c) {


### PR DESCRIPTION
Fixes #568.
