### PR TITLE
Clarify vectorization-enabled build errors.

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -287,16 +287,17 @@ Vectorization
 -------------
 
 Explicit vectorization of computational kernels can be enabled in Arbor by setting the
-``ARB_VECTORIZE`` CMake flag:
+``ARB_VECTORIZE`` CMake flag. This option is typically used in conjunction with the
+``ARB_ARCH`` option to specify the target architecture: without SIMD support in Arbor
+for the architecture, enabling ``ARB_VECTORIZE`` will lead to a compilation error.
 
 .. code-block:: bash
 
-    cmake -DARB_VECTORIZE=ON
+    cmake -DARB_VECTORIZE=ON -DARB_ARCH=native
 
 With this flag set, the library will use architecture-specific vectorization intrinsics
 to implement these kernels. Arbor currently has vectorization support for x86 architectures
-with AVX, AVX2 or AVX512 ISA extensions. Enabling the `ARB_VECTORIZE` option for a target
-without support in Arbor will give a compilation error.
+with AVX, AVX2 or AVX512 ISA extensions.
 
 .. _gpu:
 

--- a/include/arbor/simd/simd.hpp
+++ b/include/arbor/simd/simd.hpp
@@ -56,6 +56,8 @@ namespace simd_detail {
 
     template <typename Impl>
     struct simd_impl {
+        static_assert(!std::is_void<Impl>::value, "no such SIMD ABI supported");
+
         // Type aliases:
         //
         //     scalar_type           internal value type in one simd lane,

--- a/include/arbor/util/compat.hpp
+++ b/include/arbor/util/compat.hpp
@@ -42,7 +42,7 @@ inline void compiler_barrier_if_icc_leq(unsigned ver) {
 // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85597
 
 template <typename T>
-#if defined(__GNUC__) &&\
+#if !defined(__clang__) && defined(__GNUC__) &&\
     ( __GNUC__<6 ||\
      (__GNUC__==6 && __GNUC_MINOR__*100 + __GNUC_PATCHLEVEL__ < 401) ||\
      (__GNUC__==7 && __GNUC_MINOR__*100 + __GNUC_PATCHLEVEL__ < 301) ||\


### PR DESCRIPTION
Fixes #587.

* Eliminate Clang warnings from GCC-tree-optimization bug work-around.
* Error with static-assert if simd type is used with a missing simd abi.
* Clarify install documentation regarding use of ARB_VECTORIZE with ARB_ARCH.