### PR TITLE
repair compiler warnings with AppleClang

### DIFF
--- a/aux/ioutil.cpp
+++ b/aux/ioutil.cpp
@@ -18,7 +18,7 @@ std::fstream open_or_throw(const path& p, std::ios_base::openmode mode, bool exc
         throw std::runtime_error(strsub("unable to open file %", p));
     }
 
-    return std::move(file);
+    return file;
 }
 
 } // namespace aux

--- a/cmake/CompilerOptions.cmake
+++ b/cmake/CompilerOptions.cmake
@@ -13,13 +13,14 @@ endif()
 set(CXXOPT_WALL
     -Wall
 
-    # XL C:
+    # Clang:
     #
     # * Disable 'missing-braces' warning: this will inappropriately
     #   flag initializations such as
     #       std::array<int,3> a={1,2,3};
 
-    $<IF:$<CXX_COMPILER_ID:XL>,-Wno-missing-braces,>
+    $<IF:$<CXX_COMPILER_ID:Clang>,-Wno-missing-braces,>
+    $<IF:$<CXX_COMPILER_ID:AppleClang>,-Wno-missing-braces,>
 
     # Clang:
     #
@@ -28,6 +29,7 @@ set(CXXOPT_WALL
     #   effects.
 
     $<IF:$<CXX_COMPILER_ID:Clang>,-Wno-potentially-evaluated-expression,>
+    $<IF:$<CXX_COMPILER_ID:AppleClang>,-Wno-potentially-evaluated-expression,>
 
     # * Clang erroneously warns that T is an 'unused type alias'
     #   in code like this:
@@ -37,10 +39,12 @@ set(CXXOPT_WALL
     #       };
 
     $<IF:$<CXX_COMPILER_ID:Clang>,-Wno-unused-local-typedef,>
+    $<IF:$<CXX_COMPILER_ID:AppleClang>,-Wno-unused-local-typedef,>
 
     # * Ignore warning if string passed to snprintf is not a string literal.
 
     $<IF:$<CXX_COMPILER_ID:Clang>,-Wno-format-security,>
+    $<IF:$<CXX_COMPILER_ID:AppleClang>,-Wno-format-security,>
 
     # GCC:
     #

--- a/example/brunel/brunel_miniapp.cpp
+++ b/example/brunel/brunel_miniapp.cpp
@@ -63,7 +63,7 @@ class brunel_recipe: public recipe {
 public:
     brunel_recipe(cell_size_type nexc, cell_size_type ninh, cell_size_type next, double in_degree_prop,
                   float weight, float delay, float rel_inh_strength, double poiss_lambda, int seed = 42):
-        ncells_exc_(nexc), ncells_inh_(ninh), ncells_ext_(next), delay_(delay), seed_(seed) {
+        ncells_exc_(nexc), ncells_inh_(ninh), delay_(delay), seed_(seed) {
         // Make sure that in_degree_prop in the interval (0, 1]
         if (in_degree_prop <= 0.0 || in_degree_prop > 1.0) {
             std::out_of_range("The proportion of incoming connections should be in the interval (0, 1].");
@@ -155,9 +155,6 @@ private:
 
     // Number of inhibitory cells.
     cell_size_type ncells_inh_;
-
-    // Number of Poisson connections each neuron receives 
-    cell_size_type ncells_ext_;
 
     // Weight of excitatory synapses.
     float weight_exc_;


### PR DESCRIPTION
Turns out that CMake thinks Clang and AppleClang are different things.

This PR makes both CMake and AppleClang disable the same compiler warnings. 